### PR TITLE
fix(core): retry streaming transport errors wrapped by ModelHttpException without status code

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/model/ExecutionConfig.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/ExecutionConfig.java
@@ -103,7 +103,11 @@ public class ExecutionConfig {
             return hte.isRetryable();
         }
 
-        if (error instanceof ModelHttpException mhe) {
+        // Only treat a ModelHttpException as an HTTP response error when a status code is
+        // present. Implementations without a status code (e.g. OpenAIException wrapping a
+        // streaming transport failure) must fall through to the transport/IO and cause-chain
+        // checks below instead of being classified as a permanent client error (issue #3057).
+        if (error instanceof ModelHttpException mhe && mhe.getStatusCode() != null) {
             return mhe.isRetryableHttpStatus();
         }
 

--- a/agentscope-core/src/main/java/io/agentscope/core/model/ModelUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/ModelUtils.java
@@ -16,6 +16,7 @@
 package io.agentscope.core.model;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,25 +111,57 @@ public final class ModelUtils {
                 if (retryOn == null) {
                     retryOn = error -> true; // retry all errors by default
                 }
+                // Lambda captures below require effectively final variables
+                final int retryCount = maxAttempts - 1;
+                final Duration effectiveInitialBackoff = initialBackoff;
+                final Duration effectiveMaxBackoff = maxBackoff;
+                final Predicate<Throwable> effectiveRetryOn = retryOn;
 
-                Retry retrySpec =
-                        Retry.backoff(maxAttempts - 1, initialBackoff)
-                                .maxBackoff(maxBackoff)
-                                .jitter(0.5)
-                                .filter(retryOn)
-                                .doBeforeRetry(
-                                        signal ->
-                                                LOG.warn(
-                                                        "Retrying model request (attempt {}/{}) due"
-                                                                + " to: {}",
-                                                        signal.totalRetriesInARow() + 1,
-                                                        maxAttempts - 1,
-                                                        signal.failure().getMessage(),
-                                                        signal.failure()));
-
-                responseFlux = responseFlux.retryWhen(retrySpec);
+                // Retrying is only safe before the first response is emitted: resubscribing
+                // after partial output would reissue the request and downstream would observe
+                // the first partial response followed by the retried one, duplicating content.
+                // The emission flag is created inside defer so every subscription (model call)
+                // gets a fresh flag, while it persists across retry attempts of the same call.
+                final Flux<ChatResponse> source = responseFlux;
+                responseFlux =
+                        Flux.defer(
+                                () -> {
+                                    AtomicBoolean emittedAnyResponse = new AtomicBoolean(false);
+                                    return source.doOnNext(response -> emittedAnyResponse.set(true))
+                                            .retryWhen(
+                                                    Retry.backoff(
+                                                                    retryCount,
+                                                                    effectiveInitialBackoff)
+                                                            .maxBackoff(effectiveMaxBackoff)
+                                                            .jitter(0.5)
+                                                            .filter(
+                                                                    error ->
+                                                                            !emittedAnyResponse
+                                                                                            .get()
+                                                                                    && effectiveRetryOn
+                                                                                            .test(
+                                                                                                    error))
+                                                            .doBeforeRetry(
+                                                                    signal ->
+                                                                            LOG.warn(
+                                                                                    "Retrying model"
+                                                                                        + " request"
+                                                                                        + " (attempt"
+                                                                                        + " {}/{})"
+                                                                                        + " due to:"
+                                                                                        + " {}",
+                                                                                    signal
+                                                                                                    .totalRetriesInARow()
+                                                                                            + 1,
+                                                                                    retryCount,
+                                                                                    signal.failure()
+                                                                                            .getMessage(),
+                                                                                    signal
+                                                                                            .failure())));
+                                });
                 LOG.debug(
-                        "Applied retry config: maxAttempts={}, initialBackoff={} for model: {}",
+                        "Applied retry config: maxAttempts={}, initialBackoff={},"
+                                + " retryBeforeFirstResponse=true for model: {}",
                         maxAttempts,
                         initialBackoff,
                         modelName);

--- a/agentscope-core/src/main/java/io/agentscope/core/model/ModelUtils.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/model/ModelUtils.java
@@ -15,7 +15,9 @@
  */
 package io.agentscope.core.model;
 
+import io.agentscope.core.message.ContentBlock;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import org.slf4j.Logger;
@@ -117,17 +119,24 @@ public final class ModelUtils {
                 final Duration effectiveMaxBackoff = maxBackoff;
                 final Predicate<Throwable> effectiveRetryOn = retryOn;
 
-                // Retrying is only safe before the first response is emitted: resubscribing
+                // Retrying is only safe before user-visible content is emitted: resubscribing
                 // after partial output would reissue the request and downstream would observe
                 // the first partial response followed by the retried one, duplicating content.
-                // The emission flag is created inside defer so every subscription (model call)
-                // gets a fresh flag, while it persists across retry attempts of the same call.
+                // The visibility flag is created inside defer so every subscription (model
+                // call) gets a fresh flag, while it persists across retry attempts of the same
+                // call. Role-only or usage-only chunks carry no content blocks and do not
+                // disable retries — nothing user-visible has been delivered yet.
                 final Flux<ChatResponse> source = responseFlux;
                 responseFlux =
                         Flux.defer(
                                 () -> {
-                                    AtomicBoolean emittedAnyResponse = new AtomicBoolean(false);
-                                    return source.doOnNext(response -> emittedAnyResponse.set(true))
+                                    AtomicBoolean emittedVisibleContent = new AtomicBoolean(false);
+                                    return source.doOnNext(
+                                                    response -> {
+                                                        if (hasVisibleContent(response)) {
+                                                            emittedVisibleContent.set(true);
+                                                        }
+                                                    })
                                             .retryWhen(
                                                     Retry.backoff(
                                                                     retryCount,
@@ -135,12 +144,36 @@ public final class ModelUtils {
                                                             .maxBackoff(effectiveMaxBackoff)
                                                             .jitter(0.5)
                                                             .filter(
-                                                                    error ->
-                                                                            !emittedAnyResponse
-                                                                                            .get()
-                                                                                    && effectiveRetryOn
-                                                                                            .test(
-                                                                                                    error))
+                                                                    error -> {
+                                                                        if (emittedVisibleContent
+                                                                                .get()) {
+                                                                            if (effectiveRetryOn
+                                                                                    .test(error)) {
+                                                                                LOG.warn(
+                                                                                        "Skipping"
+                                                                                            + " retry"
+                                                                                            + " of retryable"
+                                                                                            + " error"
+                                                                                            + " because"
+                                                                                            + " visible"
+                                                                                            + " content"
+                                                                                            + " was already"
+                                                                                            + " emitted"
+                                                                                            + " (retrying"
+                                                                                            + " would"
+                                                                                            + " duplicate"
+                                                                                            + " it):"
+                                                                                            + " model={},"
+                                                                                            + " error={}",
+                                                                                        modelName,
+                                                                                        error
+                                                                                                .getMessage());
+                                                                            }
+                                                                            return false;
+                                                                        }
+                                                                        return effectiveRetryOn
+                                                                                .test(error);
+                                                                    })
                                                             .doBeforeRetry(
                                                                     signal ->
                                                                             LOG.warn(
@@ -169,6 +202,20 @@ public final class ModelUtils {
         }
 
         return responseFlux;
+    }
+
+    /**
+     * Whether the response carries user-visible content (text, thinking or tool-call deltas).
+     *
+     * <p>Role-only or usage-only chunks carry no content blocks — nothing user-visible has
+     * been delivered, so retrying past them cannot duplicate content.</p>
+     *
+     * @param response the response chunk to inspect
+     * @return true if the chunk contains at least one content block
+     */
+    private static boolean hasVisibleContent(ChatResponse response) {
+        List<ContentBlock> content = response.getContent();
+        return content != null && !content.isEmpty();
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/model/ExecutionConfigTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/ExecutionConfigTest.java
@@ -18,6 +18,8 @@ package io.agentscope.core.model;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.agentscope.core.model.transport.HttpTransportException;
+import java.net.SocketException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -57,6 +59,30 @@ class ExecutionConfigTest {
         assertFalse(ExecutionConfig.RETRYABLE_ERRORS.test(new TestModelHttpException(null)));
     }
 
+    @Test
+    @DisplayName("Should retry model HTTP exception without status code wrapping transport error")
+    void shouldRetryModelHttpExceptionWithoutStatusCodeWrappingTransportError() {
+        // Reproduces issue #3057: streaming transport failures are wrapped by model
+        // exceptions without an HTTP status code (e.g. OpenAIException), so the cause
+        // chain must be consulted instead of treating them as permanent client errors.
+        HttpTransportException transportError =
+                new HttpTransportException(
+                        "SSE/NDJSON stream failed: Connection reset",
+                        new SocketException("Connection reset"));
+        TestModelHttpException wrapped = new TestModelHttpException(null, transportError);
+
+        assertTrue(ExecutionConfig.RETRYABLE_ERRORS.test(wrapped));
+    }
+
+    @Test
+    @DisplayName("Should retry model HTTP exception without status code wrapping IO error")
+    void shouldRetryModelHttpExceptionWithoutStatusCodeWrappingIoError() {
+        TestModelHttpException wrapped =
+                new TestModelHttpException(null, new SocketException("Connection reset"));
+
+        assertTrue(ExecutionConfig.RETRYABLE_ERRORS.test(wrapped));
+    }
+
     private static final class TestModelHttpException extends RuntimeException
             implements ModelHttpException {
 
@@ -64,6 +90,11 @@ class ExecutionConfigTest {
 
         private TestModelHttpException(Integer statusCode) {
             super("HTTP " + statusCode);
+            this.statusCode = statusCode;
+        }
+
+        private TestModelHttpException(Integer statusCode, Throwable cause) {
+            super("HTTP " + statusCode, cause);
             this.statusCode = statusCode;
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/model/ModelTimeoutRetryTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/ModelTimeoutRetryTest.java
@@ -316,6 +316,53 @@ class ModelTimeoutRetryTest {
         assertEquals(1, attemptCount.get());
     }
 
+    @Test
+    @DisplayName("Should retry after role-only chunks that carry no visible content")
+    void shouldRetryAfterEmptyContentChunks() {
+        AtomicInteger attemptCount = new AtomicInteger(0);
+
+        // First attempt emits a role-only chunk (no content blocks) before the connection
+        // resets: nothing user-visible was delivered, so retrying cannot duplicate content.
+        Flux<ChatResponse> source =
+                Flux.defer(
+                        () -> {
+                            if (attemptCount.incrementAndGet() == 1) {
+                                return Flux.concat(
+                                        Flux.just(
+                                                new ChatResponse(
+                                                        "role-only-chunk",
+                                                        List.of(),
+                                                        null,
+                                                        null,
+                                                        null)),
+                                        Flux.error(
+                                                new HttpTransportException(
+                                                        "SSE/NDJSON stream failed: Connection"
+                                                                + " reset",
+                                                        new SocketException("Connection reset"))));
+                            }
+                            return Flux.just(createMockResponse());
+                        });
+
+        ExecutionConfig executionConfig =
+                ExecutionConfig.builder()
+                        .maxAttempts(3)
+                        .initialBackoff(Duration.ofMillis(10))
+                        .build();
+        GenerateOptions options =
+                GenerateOptions.builder().executionConfig(executionConfig).build();
+
+        StepVerifier.create(
+                        ModelUtils.applyTimeoutAndRetry(
+                                source, options, null, "test-model", "test"))
+                // role-only chunk of attempt 1 + the full response of attempt 2
+                .expectNextCount(2)
+                .verifyComplete();
+
+        // The role-only chunk carries no visible content, so a retry was allowed
+        assertEquals(2, attemptCount.get());
+    }
+
     // Helper methods to create test models
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/model/ModelTimeoutRetryTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/model/ModelTimeoutRetryTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.agentscope.core.message.Msg;
 import io.agentscope.core.message.MsgRole;
 import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.transport.HttpTransportException;
+import java.net.SocketException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -236,6 +238,81 @@ class ModelTimeoutRetryTest {
                 .verify();
 
         // Should only attempt once
+        assertEquals(1, attemptCount.get());
+    }
+
+    @Test
+    @DisplayName("Should retry connection reset before the first response is emitted")
+    void shouldRetryConnectionResetBeforeFirstResponseEmitted() {
+        AtomicInteger attemptCount = new AtomicInteger(0);
+
+        // First attempt resets the connection before emitting anything (issue #3057);
+        // the retry opens a fresh connection and succeeds.
+        Flux<ChatResponse> source =
+                Flux.defer(
+                        () -> {
+                            if (attemptCount.incrementAndGet() == 1) {
+                                return Flux.error(
+                                        new HttpTransportException(
+                                                "SSE/NDJSON stream failed: Connection reset",
+                                                new SocketException("Connection reset")));
+                            }
+                            return Flux.just(createMockResponse());
+                        });
+
+        ExecutionConfig executionConfig =
+                ExecutionConfig.builder()
+                        .maxAttempts(3)
+                        .initialBackoff(Duration.ofMillis(10))
+                        .build();
+        GenerateOptions options =
+                GenerateOptions.builder().executionConfig(executionConfig).build();
+
+        StepVerifier.create(
+                        ModelUtils.applyTimeoutAndRetry(
+                                source, options, null, "test-model", "test"))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        // Nothing had been emitted when the first attempt failed, so a retry was allowed
+        assertEquals(2, attemptCount.get());
+    }
+
+    @Test
+    @DisplayName("Should not retry after a response has already been emitted")
+    void shouldNotRetryAfterResponseEmitted() {
+        AtomicInteger attemptCount = new AtomicInteger(0);
+
+        // Every attempt emits one response chunk and then the connection resets:
+        // retrying would reissue the request and duplicate the already-delivered chunk.
+        Flux<ChatResponse> source =
+                Flux.defer(
+                        () -> {
+                            attemptCount.incrementAndGet();
+                            return Flux.concat(
+                                    Flux.just(createMockResponse()),
+                                    Flux.error(
+                                            new HttpTransportException(
+                                                    "SSE/NDJSON stream failed: Connection reset",
+                                                    new SocketException("Connection reset"))));
+                        });
+
+        ExecutionConfig executionConfig =
+                ExecutionConfig.builder()
+                        .maxAttempts(3)
+                        .initialBackoff(Duration.ofMillis(10))
+                        .build();
+        GenerateOptions options =
+                GenerateOptions.builder().executionConfig(executionConfig).build();
+
+        // The already-emitted chunk is delivered, then the error propagates without retry
+        StepVerifier.create(
+                        ModelUtils.applyTimeoutAndRetry(
+                                source, options, null, "test-model", "test"))
+                .expectNextCount(1)
+                .expectError(HttpTransportException.class)
+                .verify();
+
         assertEquals(1, attemptCount.get());
     }
 

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/AnthropicRetryClassificationTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-anthropic/src/test/java/io/agentscope/extensions/model/anthropic/AnthropicRetryClassificationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.anthropic;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.model.ExecutionConfig;
+import io.agentscope.core.model.transport.HttpTransportException;
+import java.net.SocketException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Confirms the retry classification for the exception shapes this module actually produces.
+ * The anthropic model reports transport failures as {@link HttpTransportException} (it has no
+ * {@code ModelHttpException} implementation), so its classification is driven by the
+ * {@code HttpTransportException} branch of {@code ExecutionConfig.isRetryableError} and is
+ * unaffected by the null-status {@code ModelHttpException} fix — these tests pin that down.
+ *
+ * @see io.agentscope.core.model.ExecutionConfig#RETRYABLE_ERRORS
+ */
+@Tag("unit")
+@DisplayName("Anthropic Model Retry Classification Tests")
+class AnthropicRetryClassificationTest {
+
+    @Test
+    @DisplayName("Should retry connection errors without status code")
+    void shouldRetryConnectionErrorsWithoutStatusCode() {
+        HttpTransportException connectionError =
+                new HttpTransportException(
+                        "SSE/NDJSON stream failed: java.net.SocketException: Connection reset",
+                        new SocketException("Connection reset"));
+
+        assertTrue(ExecutionConfig.RETRYABLE_ERRORS.test(connectionError));
+    }
+
+    @Test
+    @DisplayName("Should retry rate limiting and server errors")
+    void shouldRetryRateLimitingAndServerErrors() {
+        assertTrue(
+                ExecutionConfig.RETRYABLE_ERRORS.test(
+                        new HttpTransportException("Too Many Requests", 429, null)));
+        assertTrue(
+                ExecutionConfig.RETRYABLE_ERRORS.test(
+                        new HttpTransportException("Service Unavailable", 503, null)));
+    }
+
+    @Test
+    @DisplayName("Should not retry client errors")
+    void shouldNotRetryClientErrors() {
+        assertFalse(
+                ExecutionConfig.RETRYABLE_ERRORS.test(
+                        new HttpTransportException("Bad Request", 400, null)));
+        assertFalse(
+                ExecutionConfig.RETRYABLE_ERRORS.test(
+                        new HttpTransportException("Unauthorized", 401, null)));
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeRetryClassificationTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-dashscope/src/test/java/io/agentscope/extensions/model/dashscope/DashScopeRetryClassificationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.dashscope;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.model.ExecutionConfig;
+import io.agentscope.core.model.transport.HttpTransportException;
+import java.net.SocketException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Confirms the retry classification for the exception shapes this module actually produces.
+ * The dashscope model reports transport failures as {@link HttpTransportException} (it has no
+ * {@code ModelHttpException} implementation), so its classification is driven by the
+ * {@code HttpTransportException} branch of {@code ExecutionConfig.isRetryableError} and is
+ * unaffected by the null-status {@code ModelHttpException} fix — these tests pin that down.
+ *
+ * @see io.agentscope.core.model.ExecutionConfig#RETRYABLE_ERRORS
+ */
+@Tag("unit")
+@DisplayName("DashScope Model Retry Classification Tests")
+class DashScopeRetryClassificationTest {
+
+    @Test
+    @DisplayName("Should retry connection errors without status code")
+    void shouldRetryConnectionErrorsWithoutStatusCode() {
+        HttpTransportException connectionError =
+                new HttpTransportException(
+                        "SSE/NDJSON stream failed: java.net.SocketException: Connection reset",
+                        new SocketException("Connection reset"));
+
+        assertTrue(ExecutionConfig.RETRYABLE_ERRORS.test(connectionError));
+    }
+
+    @Test
+    @DisplayName("Should retry rate limiting and server errors")
+    void shouldRetryRateLimitingAndServerErrors() {
+        assertTrue(
+                ExecutionConfig.RETRYABLE_ERRORS.test(
+                        new HttpTransportException("Too Many Requests", 429, null)));
+        assertTrue(
+                ExecutionConfig.RETRYABLE_ERRORS.test(
+                        new HttpTransportException("Service Unavailable", 503, null)));
+    }
+
+    @Test
+    @DisplayName("Should not retry client errors")
+    void shouldNotRetryClientErrors() {
+        assertFalse(
+                ExecutionConfig.RETRYABLE_ERRORS.test(
+                        new HttpTransportException("Bad Request", 400, null)));
+        assertFalse(
+                ExecutionConfig.RETRYABLE_ERRORS.test(
+                        new HttpTransportException("Unauthorized", 401, null)));
+    }
+}

--- a/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/exception/OpenAIExceptionRetryClassificationTest.java
+++ b/agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai/src/test/java/io/agentscope/extensions/model/openai/exception/OpenAIExceptionRetryClassificationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.model.openai.exception;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.model.ExecutionConfig;
+import io.agentscope.core.model.transport.HttpTransportException;
+import java.net.SocketException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that {@link OpenAIException} participates in the {@link ExecutionConfig#RETRYABLE_ERRORS}
+ * classification correctly, in particular for streaming transport failures wrapped without an
+ * HTTP status code (issue #3057).
+ */
+@Tag("unit")
+@DisplayName("OpenAIException Retry Classification Tests")
+class OpenAIExceptionRetryClassificationTest {
+
+    @Test
+    @DisplayName("Should retry streaming transport error wrapped without status code")
+    void shouldRetryStreamingTransportErrorWrappedWithoutStatusCode() {
+        // Reproduces the production exception chain from issue #3057:
+        // OpenAIClient.stream wraps HttpTransportException (no status code) into
+        // OpenAIException, which implements ModelHttpException with a null status.
+        HttpTransportException transportError =
+                new HttpTransportException(
+                        "SSE/NDJSON stream failed: java.net.SocketException: Connection reset",
+                        new SocketException("Connection reset"));
+        OpenAIException exception =
+                new OpenAIException(
+                        "HTTP transport error during streaming: " + transportError.getMessage(),
+                        transportError);
+
+        assertTrue(ExecutionConfig.RETRYABLE_ERRORS.test(exception));
+    }
+
+    @Test
+    @DisplayName("Should retry wrapped IO error without status code")
+    void shouldRetryWrappedIoErrorWithoutStatusCode() {
+        OpenAIException exception =
+                new OpenAIException(
+                        "HTTP transport error during streaming",
+                        new SocketException("Connection reset"));
+
+        assertTrue(ExecutionConfig.RETRYABLE_ERRORS.test(exception));
+    }
+
+    @Test
+    @DisplayName("Should keep HTTP status based classification for real responses")
+    void shouldKeepHttpStatusBasedClassificationForRealResponses() {
+        // 429/5xx remain retryable
+        assertTrue(
+                ExecutionConfig.RETRYABLE_ERRORS.test(
+                        OpenAIException.create(429, "Rate limited", null, null)));
+        assertTrue(
+                ExecutionConfig.RETRYABLE_ERRORS.test(
+                        OpenAIException.create(503, "Service unavailable", null, null)));
+        // Other 4xx remain non-retryable
+        assertFalse(
+                ExecutionConfig.RETRYABLE_ERRORS.test(
+                        OpenAIException.create(400, "Bad request", null, null)));
+        assertFalse(
+                ExecutionConfig.RETRYABLE_ERRORS.test(
+                        OpenAIException.create(401, "Unauthorized", null, null)));
+    }
+
+    @Test
+    @DisplayName("Should not retry unknown error without status code or cause")
+    void shouldNotRetryUnknownErrorWithoutStatusCodeOrCause() {
+        OpenAIException exception = new OpenAIException("Something went wrong");
+
+        assertFalse(ExecutionConfig.RETRYABLE_ERRORS.test(exception));
+    }
+}


### PR DESCRIPTION
## Description

Model exceptions that implement `ModelHttpException` but carry **no HTTP status code** (e.g. `OpenAIException` wrapping a streaming transport failure) were classified as **non-retryable** by `ExecutionConfig.isRetryableError`, because the `ModelHttpException` branch returned `isRetryableHttpStatus()` — which is `false` for a null status — **without consulting the cause chain**. This bypassed both `HttpTransportException.isRetryable()` (which correctly returns `true` for connection errors without a status code) and the `IOException` rule, contradicting the documented *"Network/IO errors are retryable"* intent.

As a result, transient connection errors such as `Connection reset` on a stale pooled connection were never retried under `MODEL_DEFAULTS`, even though the log confirms `Applied retry config: maxAttempts=3`.

Fixes #3057

## Changes

**1. Retry classification fix (`ExecutionConfig.isRetryableError`)**
Only classify by HTTP status when a status code is present (`mhe.getStatusCode() != null`); otherwise fall through to the transport/IO and cause-chain checks.

**2. Emission guard for streaming retries (`ModelUtils.applyTimeoutAndRetry`)** (per review feedback)
Retrying a streaming call after partial output has already been emitted would reissue the request and downstream would observe the first partial response followed by the retried one, duplicating content. Retries are now allowed **only before the first `ChatResponse` of the current subscription is emitted**; once any attempt has emitted, further retries are rejected regardless of the error classification. All streaming models routed through `applyTimeoutAndRetry` benefit.

## Tests

- `ExecutionConfigTest`: null-status `ModelHttpException` wrapping a `HttpTransportException` / `SocketException` must be retryable; a null-status exception **without** a retryable cause stays non-retryable (existing behavior preserved).
- `OpenAIExceptionRetryClassificationTest` (openai extension module): the exact production exception chain from issue #3057 — `OpenAIException(msg, HttpTransportException(stream failed, SocketException))` → retryable; status-code based classification (429/5xx retryable, 400/401 not) unchanged.
- `ModelTimeoutRetryTest`: connection reset **before** the first chunk → retried and succeeds; reset **after** one emitted chunk → chunk delivered, error propagates, no retry.

## How Has This Been Tested?

- [x] `mvn -pl agentscope-core test -Dtest='ExecutionConfigTest,ModelTimeoutRetryTest'` — 21/21 pass
- [x] `mvn -pl agentscope-extensions/agentscope-extensions-model/agentscope-extensions-model-openai -am test -Dtest=OpenAIExceptionRetryClassificationTest` — 4/4 pass
- [x] `mvn spotless:check` passes
- [x] Verified against the production failure from issue #3057 (DashScope compatible-mode, default `JdkHttpTransport`, ~2h idle pooled connection): the same exception chain is now classified retryable and the retry succeeds on a fresh connection

## Notes

The existing test `shouldNotRetryModelHttpExceptionWithoutStatusCode` (null status, **no cause**) still passes unchanged — only exceptions whose cause chain contains a retryable transport/IO error change behavior.
