### PR TITLE
fix(statestore): fix saveIfVersion Jackson InvalidDefinitionException when expectedVersion is UNVERSIONED

### DIFF
--- a/agentscope-extensions/agentscope-extensions-jdbc/src/main/java/io/agentscope/extensions/jdbc/state/JdbcAgentStateStore.java
+++ b/agentscope-extensions/agentscope-extensions-jdbc/src/main/java/io/agentscope/extensions/jdbc/state/JdbcAgentStateStore.java
@@ -233,7 +233,7 @@ public class JdbcAgentStateStore implements AgentStateStore {
             String userId, String sessionId, String key, State value, long expectedVersion) {
         if (expectedVersion == UNVERSIONED) {
             save(userId, sessionId, key, value);
-            return getVersioned(userId, sessionId, key, State.class).version();
+            return readVersionOnly(userId, sessionId, key);
         }
         String slotId = slotId(userId, sessionId);
         validateSlotId(slotId);
@@ -273,6 +273,26 @@ public class JdbcAgentStateStore implements AgentStateStore {
             return result[0];
         } catch (Exception e) {
             throw new RuntimeException("Failed to save state if version: " + key, e);
+        }
+    }
+
+    private long readVersionOnly(String userId, String sessionId, String key) {
+        String slotId = slotId(userId, sessionId);
+        validateSlotId(slotId);
+        validateStateKey(key);
+
+        BoundSql boundSql = dialect.sessionStateSelectVersioned(slotId, key, SINGLE_STATE_INDEX);
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(boundSql.sql())) {
+            bindParams(stmt, boundSql.params());
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) {
+                    return 0L;
+                }
+                return rs.getLong("version");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read version for state: " + key, e);
         }
     }
 

--- a/agentscope-extensions/agentscope-extensions-mysql/src/main/java/io/agentscope/extensions/mysql/state/MysqlAgentStateStore.java
+++ b/agentscope-extensions/agentscope-extensions-mysql/src/main/java/io/agentscope/extensions/mysql/state/MysqlAgentStateStore.java
@@ -425,7 +425,7 @@ public class MysqlAgentStateStore implements AgentStateStore {
             String userId, String sessionId, String key, State value, long expectedVersion) {
         if (expectedVersion == UNVERSIONED) {
             save(userId, sessionId, key, value);
-            return getVersioned(userId, sessionId, key, State.class).version();
+            return readVersionOnly(userId, sessionId, key);
         }
 
         String slotId = slotId(userId, sessionId);
@@ -446,6 +446,29 @@ public class MysqlAgentStateStore implements AgentStateStore {
             return result[0];
         } catch (Exception e) {
             throw new RuntimeException("Failed to save state if version: " + key, e);
+        }
+    }
+
+    private long readVersionOnly(String userId, String sessionId, String key) {
+        String slotId = slotId(userId, sessionId);
+        validateSessionId(slotId);
+        validateStateKey(key);
+
+        String sql = "SELECT version FROM " + getFullTableName()
+                + " WHERE session_id = ? AND state_key = ? AND item_index = 0";
+
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, slotId);
+            stmt.setString(2, key);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) {
+                    return 0L;
+                }
+                return rs.getLong("version");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read version for state: " + key, e);
         }
     }
 

--- a/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/state/PostgresAgentStateStore.java
+++ b/agentscope-extensions/agentscope-extensions-postgresql/src/main/java/io/agentscope/extensions/postgresql/state/PostgresAgentStateStore.java
@@ -330,7 +330,7 @@ public class PostgresAgentStateStore implements AgentStateStore {
             String userId, String sessionId, String key, State value, long expectedVersion) {
         if (expectedVersion == UNVERSIONED) {
             save(userId, sessionId, key, value);
-            return getVersioned(userId, sessionId, key, State.class).version();
+            return readVersionOnly(userId, sessionId, key);
         }
 
         String slotId = slotId(userId, sessionId);
@@ -351,6 +351,29 @@ public class PostgresAgentStateStore implements AgentStateStore {
             return result[0];
         } catch (Exception e) {
             throw new RuntimeException("Failed to save state if version: " + key, e);
+        }
+    }
+
+    private long readVersionOnly(String userId, String sessionId, String key) {
+        String slotId = slotId(userId, sessionId);
+        validateSessionId(slotId);
+        validateStateKey(key);
+
+        String sql = "SELECT version FROM " + getFullTableName()
+                + " WHERE session_id = ? AND state_key = ? AND item_index = 0";
+
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, slotId);
+            stmt.setString(2, key);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next()) {
+                    return 0L;
+                }
+                return rs.getLong("version");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read version for state: " + key, e);
         }
     }
 

--- a/agentscope-extensions/agentscope-extensions-redis/src/main/java/io/agentscope/extensions/redis/state/RedisAgentStateStore.java
+++ b/agentscope-extensions/agentscope-extensions-redis/src/main/java/io/agentscope/extensions/redis/state/RedisAgentStateStore.java
@@ -270,8 +270,7 @@ public class RedisAgentStateStore implements AgentStateStore {
             String userId, String sessionId, String key, State value, long expectedVersion) {
         if (expectedVersion == UNVERSIONED) {
             save(userId, sessionId, key, value);
-            VersionedState<State> after = getVersioned(userId, sessionId, key, State.class);
-            return after.version();
+            return readVersionOnly(userId, sessionId, key);
         }
         String slotId = slotId(userId, sessionId);
         String redisKey = getStateKey(slotId, key);
@@ -287,6 +286,25 @@ public class RedisAgentStateStore implements AgentStateStore {
             return result == -1L ? UNVERSIONED : result;
         } catch (Exception e) {
             throw new RuntimeException("Failed to save state if version: " + key, e);
+        }
+    }
+
+    /**
+     * Read only the version number without deserializing the payload.
+     * This avoids Jackson's inability to deserialize the State marker interface.
+     */
+    private long readVersionOnly(String userId, String sessionId, String key) {
+        String slotId = slotId(userId, sessionId);
+        String redisKey = getStateKey(slotId, key);
+        String versionKey = RedisStateVersionSupport.versionKey(redisKey);
+        try {
+            String json = client.get(redisKey);
+            if (json == null) {
+                return 0L;
+            }
+            return RedisStateVersionSupport.parseVersion(json, client.get(versionKey));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read version for state: " + key, e);
         }
     }
 

--- a/agentscope-extensions/agentscope-extensions-redis/src/main/java/io/agentscope/extensions/redis/state/jedis/JedisAgentStateStore.java
+++ b/agentscope-extensions/agentscope-extensions-redis/src/main/java/io/agentscope/extensions/redis/state/jedis/JedisAgentStateStore.java
@@ -119,9 +119,24 @@ public class JedisAgentStateStore implements AgentStateStore {
             String userId, String sessionId, String key, State value, long expectedVersion) {
         if (expectedVersion == UNVERSIONED) {
             save(userId, sessionId, key, value);
-            return getVersioned(userId, sessionId, key, State.class).version();
+            return readVersionOnly(userId, sessionId, key);
         }
         return evalSave(userId, sessionId, key, value, Long.toString(expectedVersion));
+    }
+
+    private long readVersionOnly(String userId, String sessionId, String key) {
+        String slotId = slotId(userId, sessionId);
+        String redisKey = getStateKey(slotId, key);
+        String versionKey = RedisStateVersionSupport.versionKey(redisKey);
+        try (Jedis jedis = jedisPool.getResource()) {
+            String json = jedis.get(redisKey);
+            if (json == null) {
+                return 0L;
+            }
+            return RedisStateVersionSupport.parseVersion(json, jedis.get(versionKey));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read version for state: " + key, e);
+        }
     }
 
     private long evalSave(

--- a/agentscope-extensions/agentscope-extensions-redis/src/main/java/io/agentscope/extensions/redis/state/redisson/RedissonAgentStateStore.java
+++ b/agentscope-extensions/agentscope-extensions-redis/src/main/java/io/agentscope/extensions/redis/state/redisson/RedissonAgentStateStore.java
@@ -125,9 +125,26 @@ public class RedissonAgentStateStore implements AgentStateStore {
             String userId, String sessionId, String key, State value, long expectedVersion) {
         if (expectedVersion == UNVERSIONED) {
             save(userId, sessionId, key, value);
-            return getVersioned(userId, sessionId, key, State.class).version();
+            return readVersionOnly(userId, sessionId, key);
         }
         return evalSave(userId, sessionId, key, value, Long.toString(expectedVersion));
+    }
+
+    private long readVersionOnly(String userId, String sessionId, String key) {
+        String slotId = slotId(userId, sessionId);
+        String redisKey = getStateKey(slotId, key);
+        String versionKey = RedisStateVersionSupport.versionKey(redisKey);
+        try {
+            RBucket<String> bucket = redissonClient.getBucket(redisKey, StringCodec.INSTANCE);
+            String json = bucket.get();
+            if (json == null) {
+                return 0L;
+            }
+            RBucket<String> versionBucket = redissonClient.getBucket(versionKey, StringCodec.INSTANCE);
+            return RedisStateVersionSupport.parseVersion(json, versionBucket.get());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read version for state: " + key, e);
+        }
     }
 
     private long evalSave(


### PR DESCRIPTION
## Problem

When `AgentStateStore.saveIfVersion(userId, sessionId, key, value, UNVERSIONED)` is called on any versioning backend (JDBC, MySQL, PostgreSQL, or Redis Jedis/Redisson/unified), it throws `InvalidDefinitionException` because the implementation tries to deserialize the state back as the `State` marker interface to obtain the version number:

```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException:
Cannot construct instance of io.agentscope.core.state.State (no Creators, like default constructor, exist):
abstract types either need to be mapped to concrete types, have custom deserializer, or contain additional type information
```

### Root Cause

In the `expectedVersion == UNVERSIONED` branch, every versioning implementation calls:
```java
getVersioned(userId, sessionId, key, State.class).version()
```
`State` is a marker interface — Jackson cannot deserialize JSON into an interface type.

### Stack Trace
```
at io.agentscope.extensions.mysql.state.MysqlAgentStateStore.getVersioned(...)
at io.agentscope.extensions.mysql.state.MysqlAgentStateStore.saveIfVersion(...)
at io.agentscope.core.ReActAgent.persistAgentStateCas(...)
```

## Solution

Add a private `readVersionOnly(userId, sessionId, key)` method to each affected implementation that reads **only the version column** without deserializing the payload. Replace the broken `getVersioned(..., State.class).version()` call with `readVersionOnly(...)`.

## Changes

| File | Change |
|------|--------|
| `RedisAgentStateStore.java` | Add `readVersionOnly` using `RedisStateVersionSupport.parseVersion` |
| `JedisAgentStateStore.java` | Add `readVersionOnly` (deprecated class, same fix) |
| `RedissonAgentStateStore.java` | Add `readVersionOnly` (deprecated class, same fix) |
| `JdbcAgentStateStore.java` | Add `readVersionOnly` querying only the `version` column |
| `MysqlAgentStateStore.java` | Add `readVersionOnly` querying only the `version` column |
| `PostgresAgentStateStore.java` | Add `readVersionOnly` querying only the `version` column |

## Test Plan

- [ ] Unit test: call `saveIfVersion(..., UNVERSIONED)` on each backend and verify it returns the new version number (e.g. `2L`) without throwing
- [ ] Integration test: run against real Redis / H2 / MySQL / PostgreSQL
- [ ] Regression: verify other `AgentStateStore` methods (`getVersioned`, `save`, `delete`) are unaffected

Fixes #3047