### PR TITLE
fix(core): evict slot versions with state cache

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -4227,6 +4227,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
     public void clearStateCache() {
         stateCache.clear();
         permissionEngineCache.clear();
+        slotVersions.clear();
     }
 
     /**
@@ -4257,6 +4258,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
         String slot = slotKey(userId, sid);
         stateCache.remove(slot);
         permissionEngineCache.remove(slot);
+        slotVersions.remove(slot);
     }
 
     /**

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentPerSessionStateTest.java
@@ -44,10 +44,12 @@ import io.agentscope.core.state.InMemoryAgentStateStore;
 import io.agentscope.core.state.JsonFileAgentStateStore;
 import io.agentscope.core.state.legacy.ToolkitState;
 import io.agentscope.core.tool.Toolkit;
+import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -87,6 +89,13 @@ class ReActAgentPerSessionStateTest {
                 .model(new NoopModel())
                 .stateStore(store)
                 .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static int slotVersionCount(ReActAgent agent) throws Exception {
+        Field field = ReActAgent.class.getDeclaredField("slotVersions");
+        field.setAccessible(true);
+        return ((Map<String, Long>) field.get(agent)).size();
     }
 
     @Test
@@ -193,6 +202,22 @@ class ReActAgentPerSessionStateTest {
 
         assertNotSame(target, agent.getAgentState("u1", "sessA"));
         assertSame(other, agent.getAgentState("u1", "sessB"));
+    }
+
+    @Test
+    @DisplayName("clearStateCache evicts optimistic-concurrency versions with session caches")
+    void clearStateCacheEvictsSlotVersions() throws Exception {
+        ReActAgent agent = agent(new InMemoryAgentStateStore());
+
+        agent.getAgentState("u1", "sessA");
+        agent.getAgentState("u1", "sessB");
+        assertEquals(2, slotVersionCount(agent));
+
+        agent.clearStateCache("u1", "sessA");
+        assertEquals(1, slotVersionCount(agent));
+
+        agent.clearStateCache();
+        assertEquals(0, slotVersionCount(agent));
     }
 
     @Test


### PR DESCRIPTION
Fixes #3073

## Summary

ReActAgent keeps optimistic-concurrency versions in `slotVersions`, parallel to the per-session state cache. Both `clearStateCache()` overloads evict state and permission entries but leave the version map populated indefinitely for long-lived agents.

This change keeps the three per-slot caches aligned:
- clear all removes all slot versions.
- clear one removes only that slot version.
- Existing state-store behavior and public APIs are unchanged.

## Verification

```text
mvn -pl agentscope-core -Dtest=ReActAgentPerSessionStateTest -Dspotless.check.skip=true test
Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
mvn -pl agentscope-core spotless:apply
```

Signed-off-by: Yohanes <CryoThrust@users.noreply.github.com>
