### PR TITLE
feat(harness): allow disabling built-in web tools

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -1239,6 +1239,7 @@ public class HarnessAgent implements Agent, AutoCloseable {
         ArtifactDeliveryTarget artifactDeliveryTarget;
         boolean disableFilesystemTools = false;
         boolean disableShellTool = false;
+        boolean disableWebTools = false;
         boolean disableMemoryTools = false;
         boolean disableMemoryHooks = false;
         boolean disableTranscript = false;
@@ -2044,6 +2045,12 @@ public class HarnessAgent implements Agent, AutoCloseable {
             return this;
         }
 
+        /** Skips registration of the optional Tavily-backed {@code web_search} and {@code web_fetch} tools. */
+        public Builder disableWebTools() {
+            this.disableWebTools = true;
+            return this;
+        }
+
         /**
          * Registers schema-only external tools on the builder toolkit (merged into the final
          * agent toolkit at {@link #build()}). Used by {@code self_hosted} environments to expose
@@ -2677,8 +2684,10 @@ public class HarnessAgent implements Agent, AutoCloseable {
             if (!disableShellTool && filesystem instanceof AbstractSandboxFilesystem sandbox) {
                 agentToolkit.registerTool(new ShellExecuteTool(sandbox));
             }
-            agentToolkit.registerTool(new WebTools.WebFetchTool());
-            agentToolkit.registerTool(new WebTools.WebSearchTool());
+            if (!disableWebTools) {
+                agentToolkit.registerTool(new WebTools.WebFetchTool());
+                agentToolkit.registerTool(new WebTools.WebSearchTool());
+            }
 
             // ---- Plan mode (read-only design phase) ----
             PlanModeManager planModeManager = null;

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -230,6 +230,26 @@ class HarnessAgentTest {
     }
 
     @Test
+    void disableWebTools_omitsOptionalWebTools() throws Exception {
+        Files.createDirectories(workspace);
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .disableWebTools()
+                        .build();
+
+        List<String> toolNames =
+                agent.getDelegate().getToolkit().getToolSchemas().stream()
+                        .map(ToolSchema::getName)
+                        .toList();
+        assertFalse(toolNames.contains("web_search"));
+        assertFalse(toolNames.contains("web_fetch"));
+    }
+
+    @Test
     void artifactDeliveryTarget_registersDeliverTool() throws Exception {
         Files.createDirectories(workspace);
         Model model = stubModel("ok");


### PR DESCRIPTION
Fixes #3068

## Summary

`HarnessAgent.Builder` now provides an explicit `disableWebTools()` opt-out for the optional built-in `web_search` and `web_fetch` tools.

This keeps the existing default behavior unchanged while allowing applications that provide their own web tools, or do not configure Tavily, to avoid name collisions and accidental runtime errors. The public web-tool classes remain available for explicit registration.

## Changes

- add a builder flag and `disableWebTools()` method;
- guard built-in web-tool registration with the flag;
- add a regression test asserting both web tool schemas are absent when disabled.

## Verification

```text
mvn -s /Users/yohanes/.m2/settings-public-central.xml -pl agentscope-harness -am -Dtest=HarnessAgentTest -Dspotless.check.skip=true test
Tests run: 50, Failures: 0, Errors: 0, Skipped: 0
mvn -s /Users/yohanes/.m2/settings-public-central.xml -pl agentscope-harness spotless:apply
```

Signed-off-by: Yohanes <CryoThrust@users.noreply.github.com>
