### PR TITLE
fix(state): return unconditional write versions atomically

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/state/InMemoryAgentStateStore.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/state/InMemoryAgentStateStore.java
@@ -51,6 +51,13 @@ public class InMemoryAgentStateStore implements AgentStateStore {
     /** users → (sessionId → SessionData) */
     private final Map<String, Map<String, SessionData>> users = new ConcurrentHashMap<>();
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>{@link #saveIfVersion} writes directly through the internal atomic versioning operation,
+     * including unconditional writes; it does not invoke this method. Subclasses that intercept
+     * single-state writes should override both entry points.
+     */
     @Override
     public void save(String userId, String sessionId, String key, State value) {
         SessionData data = lookupOrCreate(userId, sessionId);
@@ -86,6 +93,13 @@ public class InMemoryAgentStateStore implements AgentStateStore {
         return new VersionedState<>(type.cast(state), entry.version());
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The state write and its returned version are determined in the same critical section. This
+     * method does not delegate to {@link #save(String, String, String, State)}, even when {@code
+     * expectedVersion == UNVERSIONED}.
+     */
     @Override
     public long saveIfVersion(
             String userId, String sessionId, String key, State value, long expectedVersion) {

--- a/agentscope-core/src/main/java/io/agentscope/core/state/InMemoryAgentStateStore.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/state/InMemoryAgentStateStore.java
@@ -209,10 +209,8 @@ public class InMemoryAgentStateStore implements AgentStateStore {
         private final Map<String, VersionedEntry> singleStates = new ConcurrentHashMap<>();
         private final Map<String, List<State>> listStates = new ConcurrentHashMap<>();
 
-        synchronized void setSingleState(String key, State value) {
-            VersionedEntry prev = singleStates.get(key);
-            long next = prev == null ? 1L : prev.version() + 1L;
-            singleStates.put(key, new VersionedEntry(value, next));
+        void setSingleState(String key, State value) {
+            casSingleState(key, value, UNVERSIONED);
         }
 
         synchronized long casSingleState(String key, State value, long expectedVersion) {

--- a/agentscope-core/src/main/java/io/agentscope/core/state/InMemoryAgentStateStore.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/state/InMemoryAgentStateStore.java
@@ -89,12 +89,6 @@ public class InMemoryAgentStateStore implements AgentStateStore {
     @Override
     public long saveIfVersion(
             String userId, String sessionId, String key, State value, long expectedVersion) {
-        if (expectedVersion == UNVERSIONED) {
-            save(userId, sessionId, key, value);
-            SessionData data = lookup(userId, sessionId);
-            VersionedEntry entry = data != null ? data.getVersionedSingleState(key) : null;
-            return entry != null ? entry.version() : UNVERSIONED;
-        }
         SessionData data = lookupOrCreate(userId, sessionId);
         return data.casSingleState(key, value, expectedVersion);
     }
@@ -224,10 +218,10 @@ public class InMemoryAgentStateStore implements AgentStateStore {
         synchronized long casSingleState(String key, State value, long expectedVersion) {
             VersionedEntry prev = singleStates.get(key);
             long current = prev == null ? 0L : prev.version();
-            if (current != expectedVersion) {
+            if (expectedVersion != UNVERSIONED && current != expectedVersion) {
                 return UNVERSIONED;
             }
-            long next = expectedVersion + 1L;
+            long next = current + 1L;
             singleStates.put(key, new VersionedEntry(value, next));
             return next;
         }

--- a/agentscope-core/src/test/java/io/agentscope/core/state/InMemoryAgentStateStoreConcurrencyTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/state/InMemoryAgentStateStoreConcurrencyTest.java
@@ -17,7 +17,13 @@ package io.agentscope.core.state;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -88,6 +94,69 @@ class InMemoryAgentStateStoreConcurrencyTest {
                             "key",
                             new TestState("stale"),
                             Math.min(firstVersion, secondVersion)));
+            assertEquals(latest, store.getVersioned("user", "session", "key", TestState.class));
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    @Timeout(15)
+    void concurrentUnconditionalWritesReturnUniqueVersions() throws Exception {
+        int writers = 4;
+        int writesPerWriter = 200;
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        CyclicBarrier startRound = new CyclicBarrier(writers);
+        ExecutorService pool = Executors.newFixedThreadPool(writers);
+        try {
+            List<Future<List<VersionedState<TestState>>>> results = new ArrayList<>();
+            for (int writer = 0; writer < writers; writer++) {
+                int writerId = writer;
+                results.add(
+                        pool.submit(
+                                () -> {
+                                    List<VersionedState<TestState>> writes = new ArrayList<>();
+                                    for (int iteration = 0;
+                                            iteration < writesPerWriter;
+                                            iteration++) {
+                                        TestState value = new TestState(writerId + ":" + iteration);
+                                        // Contend on the real store each round, without a save
+                                        // override.
+                                        startRound.await(5, TimeUnit.SECONDS);
+                                        long version =
+                                                store.saveIfVersion(
+                                                        "user",
+                                                        "session",
+                                                        "key",
+                                                        value,
+                                                        AgentStateStore.UNVERSIONED);
+                                        writes.add(new VersionedState<>(value, version));
+                                    }
+                                    return writes;
+                                }));
+            }
+
+            Map<Long, TestState> writesByVersion = new HashMap<>();
+            for (Future<List<VersionedState<TestState>>> result : results) {
+                for (VersionedState<TestState> write : result.get(10, TimeUnit.SECONDS)) {
+                    assertNull(
+                            writesByVersion.put(write.version(), write.value()),
+                            "Each write must return its own unique version");
+                }
+            }
+            long totalWrites = (long) writers * writesPerWriter;
+            assertEquals(totalWrites, writesByVersion.size());
+            for (long version = 1; version <= totalWrites; version++) {
+                assertTrue(writesByVersion.containsKey(version));
+            }
+            VersionedState<TestState> latest =
+                    store.getVersioned("user", "session", "key", TestState.class);
+            assertEquals(totalWrites, latest.version());
+            assertEquals(writesByVersion.get(latest.version()), latest.value());
+            assertEquals(
+                    AgentStateStore.UNVERSIONED,
+                    store.saveIfVersion(
+                            "user", "session", "key", new TestState("stale"), totalWrites - 1));
             assertEquals(latest, store.getVersioned("user", "session", "key", TestState.class));
         } finally {
             pool.shutdownNow();

--- a/agentscope-core/src/test/java/io/agentscope/core/state/InMemoryAgentStateStoreConcurrencyTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/state/InMemoryAgentStateStoreConcurrencyTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+class InMemoryAgentStateStoreConcurrencyTest {
+
+    @Test
+    @Timeout(15)
+    void unconditionalWritersReturnTheirOwnVersions() throws Exception {
+        CyclicBarrier bothWritesCompleted = new CyclicBarrier(2);
+        InMemoryAgentStateStore store =
+                new InMemoryAgentStateStore() {
+                    @Override
+                    public void save(String userId, String sessionId, String key, State value) {
+                        super.save(userId, sessionId, key, value);
+                        // Force both writes before either caller can read the version back.
+                        // An atomic write-and-return does not need to call this method.
+                        try {
+                            bothWritesCompleted.await(5, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException(e);
+                        } catch (Exception e) {
+                            throw new IllegalStateException(e);
+                        }
+                    }
+                };
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            Future<Long> first =
+                    pool.submit(
+                            () ->
+                                    store.saveIfVersion(
+                                            "user",
+                                            "session",
+                                            "key",
+                                            new TestState("first"),
+                                            AgentStateStore.UNVERSIONED));
+            Future<Long> second =
+                    pool.submit(
+                            () ->
+                                    store.saveIfVersion(
+                                            "user",
+                                            "session",
+                                            "key",
+                                            new TestState("second"),
+                                            AgentStateStore.UNVERSIONED));
+            long firstVersion = first.get(10, TimeUnit.SECONDS);
+            long secondVersion = second.get(10, TimeUnit.SECONDS);
+
+            assertNotEquals(firstVersion, secondVersion);
+            assertEquals(1L, Math.min(firstVersion, secondVersion));
+            assertEquals(2L, Math.max(firstVersion, secondVersion));
+            VersionedState<TestState> latest =
+                    store.getVersioned("user", "session", "key", TestState.class);
+            assertEquals(2L, latest.version());
+            assertEquals(firstVersion > secondVersion ? "first" : "second", latest.value().value());
+
+            assertEquals(
+                    AgentStateStore.UNVERSIONED,
+                    store.saveIfVersion(
+                            "user",
+                            "session",
+                            "key",
+                            new TestState("stale"),
+                            Math.min(firstVersion, secondVersion)));
+            assertEquals(latest, store.getVersioned("user", "session", "key", TestState.class));
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    record TestState(String value) implements State {}
+}


### PR DESCRIPTION
## AgentScope-Java Version

`2.0.3-SNAPSHOT`, based on main at `2b378e158ce1e555cd98c67d114d43cbc316af73`.

## Description

Fixes #3076.

Concurrent unconditional `InMemoryAgentStateStore.saveIfVersion` calls can both return the later write's version: the method saves first, then reads the version separately. A caller whose state was overwritten can consequently use that newer version to pass a subsequent CAS incorrectly.

Route unconditional writes through the existing synchronized CAS helper, skipping the comparison for `UNVERSIONED` and returning the version assigned inside the same critical section. Plain `save()` delegates to the same helper with `UNVERSIONED`, keeping version increment and write logic in one synchronized operation. Conditional writes retain their existing behavior.

The Javadoc on both entry points explicitly documents that `saveIfVersion`, including unconditional writes, does not invoke the public `save` method. Subclasses that intercept single-state writes need to override both entry points.

The regression test forces the old write/read interleaving with a barrier after `super.save()` in a test-only subclass. It checks distinct versions, their association with the persisted state, and rejection of the earlier writer's stale version. The test fails on the unmodified implementation and passes with this patch. An additional local stress reproduction using the ordinary store produced 2,563 duplicate versions in 8,000 writes before the fix, and zero after it.

A second committed test uses an ordinary store with no method overrides: four workers each perform 200 unconditional writes, rendezvousing before every round. It checks all 800 returned versions are unique and contiguous, the final state belongs to the final returned version, and a stale-version write is rejected. This contention test complements the targeted old-interleaving regression; it does not rely on the public `save()` hook or guarantee a particular thread schedule.

## Validation

- Baseline existing versioning contract: 6 tests passed.
- Both committed concurrency tests fail against unmodified current main `c5db8f72dbea5c2c70de96885e4167ce5b1b24b0` in an isolated checkout: the targeted regression returns version 2 twice, and the 800-write test detects a duplicate returned version (2 failures, 0 errors).
- After the fix: 43 tests passed, zero failures/errors/skips:

```text
mvn -B -pl agentscope-core -am '-Dtest=*StateStore*Test,ReActAgentPerSessionStateTest' '-Dsurefire.failIfNoSpecifiedTests=false' '-Dspotless.skip=true' test
```

- Spotless apply/check passed for both changed files:

```text
mvn -B -pl agentscope-core '-DspotlessFiles=.*InMemoryAgentStateStore.java,.*InMemoryAgentStateStoreConcurrencyTest.java' spotless:apply spotless:check
```

- `git diff --cached --check` passed.
- Environment: Windows 11, Temurin 17.0.15, Maven 3.9.12. The full multi-module test suite was not run locally.

## Checklist

- [x] Changed code has been formatted with Spotless.
- [x] Relevant state-store and per-session regression tests pass.
- [ ] Full repository `mvn test` (not run locally).
- [x] Public method signatures and version semantics are preserved; the change to public `save()` delegation is documented for subclasses.
- [x] Code is ready for review.

AI assistance was used to find, implement, and test this change. Validation results above are from commands executed against the local checkout.

