### PR TITLE
fix(core): derive Version.VERSION from Maven project version instead of hardcoding

### DIFF
--- a/agentscope-core/pom.xml
+++ b/agentscope-core/pom.xml
@@ -206,7 +206,77 @@
     </dependencies>
 
     <build>
+        <resources>
+            <!-- Non-filtered default, excluding the version file so this block never writes the
+                 same target path as the filtered block below. If both blocks copied
+                 META-INF/agentscope/version.properties, the unfiltered copy (which runs first and
+                 rewrites the target with a newer timestamp than the source) would make the
+                 filtered copy be skipped by maven-resources-plugin (default overwrite=false),
+                 silently packaging the literal ${project.version} placeholder. -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>META-INF/agentscope/version.properties</exclude>
+                </excludes>
+            </resource>
+            <!-- Filter only the version file so ${project.version} is resolved. This block is the
+                 sole writer of the target version.properties. -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>META-INF/agentscope/version.properties</include>
+                </includes>
+            </resource>
+        </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>agentscope-test-version.properties</exclude>
+                </excludes>
+            </testResource>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>agentscope-test-version.properties</include>
+                </includes>
+            </testResource>
+        </testResources>
         <plugins>
+            <!-- Fail the build loudly if the filtered version resource still contains the
+                 ${project.version} placeholder (i.e. Maven resource filtering did not apply).
+                 Without this check the packaged jar would silently carry an unfiltered literal,
+                 and Version.resolveVersionFrom would mask it by returning "unknown". -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>verify-version-resource-filtered</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <fail message="META-INF/agentscope/version.properties still contains the unfiltered 'dollar-brace' placeholder (the Maven project.version expression was not resolved): Maven resource filtering did not apply. Check the resource filtering configuration in agentscope-core/pom.xml.">
+                                    <condition>
+                                        <!-- A single '$' is enough to detect the unmapped
+                                             ${project.version} placeholder: the filtered file is
+                                             just 'version=2.0.3-SNAPSHOT' and contains none. -->
+                                        <resourcecontains resource="${project.build.outputDirectory}/META-INF/agentscope/version.properties" substring="$" />
+                                    </condition>
+                                </fail>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- Publish a test-jar so downstream modules (agentscope-harness) can reuse the
                  shared test fixtures (MockModel, MockToolkit, TestConstants, TestUtils). -->
             <plugin>

--- a/agentscope-core/src/main/java/io/agentscope/core/Version.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/Version.java
@@ -15,19 +15,147 @@
  */
 package io.agentscope.core;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * AgentScope version and User-Agent information.
  *
  * <p>Provides a unified User-Agent string for all model requests to identify AgentScope Java
  * clients and collect usage statistics.
+ *
+ * <p>The version is resolved at class-load time through a three-level fallback chain:
+ *
+ * <ol>
+ *   <li>the {@code META-INF/agentscope/version.properties} classpath resource, whose
+ *       {@code ${project.version}} placeholder is resolved by Maven resource filtering;
+ *   <li>the {@code Implementation-Version} manifest entry of the containing jar, which is
+ *       populated from {@code ${project.version}} by the Maven jar plugin;
+ *   <li>the literal {@code "unknown"} as a last resort (e.g. running straight from IDE
+ *       {@code target/classes} with no manifest), accompanied by a one-time warning log.
+ * </ol>
  */
 public final class Version {
 
-    /** AgentScope Java version */
-    public static final String VERSION = "1.0.13-SNAPSHOT";
+    private static final Logger log = LoggerFactory.getLogger(Version.class);
+
+    private static final String VERSION_RESOURCE = "/META-INF/agentscope/version.properties";
+
+    /** Sentinel returned when no build-resolved version can be discovered. */
+    static final String UNKNOWN = "unknown";
+
+    /**
+     * AgentScope Java version.
+     *
+     * <p>Injected at build time by Maven resource filtering from {@code ${project.version}};
+     * see the class Javadoc for the fallback chain.
+     */
+    public static final String VERSION = resolveVersion();
 
     private Version() {
         // Utility class - prevent instantiation
+    }
+
+    private static String resolveVersion() {
+        // 1) Maven-filtered classpath resource (normal Maven builds, tests).
+        String fromResource;
+        try (InputStream in = Version.class.getResourceAsStream(VERSION_RESOURCE)) {
+            fromResource = resolveVersionFromResource(in);
+        } catch (IOException e) {
+            log.debug("Failed to read {} from the classpath", VERSION_RESOURCE, e);
+            fromResource = UNKNOWN;
+        }
+        if (!UNKNOWN.equals(fromResource)) {
+            return fromResource;
+        }
+
+        // 2) jar manifest Implementation-Version (packaged jars whose META-INF/agentscope
+        //    directory may have been dropped, e.g. by shading or custom packaging).
+        String fromManifest = resolveVersionFromManifest(getImplementationVersion());
+        if (!UNKNOWN.equals(fromManifest)) {
+            log.debug(
+                    "Resolved version from jar manifest Implementation-Version: {}", fromManifest);
+            return fromManifest;
+        }
+
+        // 3) Last resort: make the failure visible instead of silently using a stale value.
+        log.warn(
+                "Could not resolve the AgentScope version from {} or the jar manifest "
+                        + "Implementation-Version; reporting '{}'. Run against a Maven-built "
+                        + "classpath for accurate versioning.",
+                VERSION_RESOURCE,
+                UNKNOWN);
+        return UNKNOWN;
+    }
+
+    /**
+     * Load and resolve the version from the classpath resource stream.
+     *
+     * <p>Package-private for unit testing.
+     *
+     * @param in stream to {@code version.properties}, or {@code null} when the resource is absent
+     * @return the resolved version, or {@code "unknown"} when the stream is {@code null} or cannot
+     *     be read
+     */
+    static String resolveVersionFromResource(InputStream in) {
+        if (in == null) {
+            return UNKNOWN;
+        }
+        try (in) {
+            Properties props = new Properties();
+            props.load(in);
+            return resolveVersionFrom(props);
+        } catch (IOException e) {
+            log.debug("Failed to read {}", VERSION_RESOURCE, e);
+            return UNKNOWN;
+        }
+    }
+
+    /**
+     * Resolve the version string from a properties object, guarding against missing, blank,
+     * and unfiltered ({@code ${...}}) values.
+     *
+     * <p>Package-private for unit testing.
+     *
+     * @param props properties loaded from the version resource
+     * @return trimmed version, or {@code "unknown"} when absent, blank, or unfiltered
+     */
+    static String resolveVersionFrom(Properties props) {
+        if (props == null) {
+            return UNKNOWN;
+        }
+        String version = props.getProperty("version");
+        // Guard against an unfiltered ${project.version} literal, e.g. when running
+        // from an IDE that does not run Maven resource filtering.
+        if (version != null && !version.isBlank() && !version.startsWith("${")) {
+            return version.trim();
+        }
+        return UNKNOWN;
+    }
+
+    /**
+     * Resolve the version from the jar manifest's {@code Implementation-Version} entry.
+     *
+     * <p>Package-private for unit testing.
+     *
+     * @param implementationVersion manifest value, or {@code null} when absent
+     * @return the resolved version, or {@code "unknown"} when absent, blank, or unfiltered
+     */
+    static String resolveVersionFromManifest(String implementationVersion) {
+        if (implementationVersion != null
+                && !implementationVersion.isBlank()
+                && !implementationVersion.startsWith("${")) {
+            return implementationVersion.trim();
+        }
+        return UNKNOWN;
+    }
+
+    private static String getImplementationVersion() {
+        Package pkg = Version.class.getPackage();
+        return pkg == null ? null : pkg.getImplementationVersion();
     }
 
     /**

--- a/agentscope-core/src/main/resources/META-INF/agentscope/version.properties
+++ b/agentscope-core/src/main/resources/META-INF/agentscope/version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/agentscope-core/src/test/java/io/agentscope/core/VersionTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/VersionTest.java
@@ -15,23 +15,175 @@
  */
 package io.agentscope.core;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link Version} class.
  *
- * <p>Verifies User-Agent string generation for identifying AgentScope Java clients.
+ * <p>Verifies the build-resolved version and User-Agent string generation for identifying
+ * AgentScope Java clients.
  */
 class VersionTest {
 
+    private static final String MAIN_VERSION_RESOURCE = "/META-INF/agentscope/version.properties";
+    private static final String TEST_VERSION_RESOURCE = "/agentscope-test-version.properties";
+    private static final String SEMVER = "\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z.-]+)?";
+
+    private static Properties loadProps(String resourcePath) throws IOException {
+        try (InputStream in = VersionTest.class.getResourceAsStream(resourcePath)) {
+            if (in == null) {
+                return null;
+            }
+            Properties props = new Properties();
+            props.load(in);
+            return props;
+        }
+    }
+
     @Test
-    void testVersionConstant() {
-        // Verify version constant is set
-        Assertions.assertNotNull(Version.VERSION, "VERSION constant should not be null");
-        Assertions.assertFalse(Version.VERSION.isEmpty(), "VERSION constant should not be empty");
+    void testVersionConstant() throws IOException {
+        Properties props = loadProps(MAIN_VERSION_RESOURCE);
+        // The resource is absent only when the build did not run Maven resource processing at
+        // all (e.g. an IDE run against raw target/classes without resources), so there is no
+        // expected value to cross-check - skip, not fail.
+        if (props == null) {
+            Assumptions.abort(
+                    MAIN_VERSION_RESOURCE
+                            + " is missing from the classpath (non-Maven/IDE run);"
+                            + " skipping strict version cross-check");
+        }
+        String expectedVersion = props.getProperty("version");
+        Assertions.assertNotNull(expectedVersion, "version property should be present");
+
+        // If the resource IS present but still contains the unfiltered ${project.version}
+        // placeholder, Maven resource filtering genuinely did not apply. That is a loud
+        // failure, not an assumption violation - a packaged jar would silently carry the
+        // placeholder while Version.resolveVersionFrom masks it as "unknown".
+        Assertions.assertFalse(
+                expectedVersion.contains("${"),
+                MAIN_VERSION_RESOURCE
+                        + " is unfiltered (still contains '${'): Maven resource filtering"
+                        + " did not apply");
+
+        // Strict cross-check: the runtime version must match the Maven project version exactly.
         Assertions.assertEquals(
-                "1.0.13-SNAPSHOT", Version.VERSION, "VERSION should match current version");
+                expectedVersion, Version.VERSION, "VERSION must match the Maven project version");
+
+        // Semantic version format check.
+        Assertions.assertTrue(
+                Version.VERSION.matches(SEMVER),
+                "VERSION should be a valid semver: " + Version.VERSION);
+    }
+
+    @Test
+    void testVersionConstant_CrossCheckTestResource() throws IOException {
+        Properties props = loadProps(TEST_VERSION_RESOURCE);
+        if (props == null) {
+            Assumptions.abort(
+                    TEST_VERSION_RESOURCE
+                            + " is missing from the classpath (non-Maven/IDE run);"
+                            + " skipping cross-check");
+        }
+        String expectedVersion = props.getProperty("version");
+        Assertions.assertNotNull(expectedVersion, "version property should be present");
+        Assertions.assertFalse(
+                expectedVersion.contains("${"), "test version.properties is unfiltered");
+        Assertions.assertEquals(
+                expectedVersion,
+                Version.VERSION,
+                "test-resource version must match the runtime VERSION");
+    }
+
+    @Test
+    void testResolveVersionFromResource_Normal() throws IOException {
+        String content = "version=2.0.3-SNAPSHOT";
+        Assertions.assertEquals(
+                "2.0.3-SNAPSHOT",
+                Version.resolveVersionFromResource(
+                        new java.io.ByteArrayInputStream(
+                                content.getBytes(java.nio.charset.StandardCharsets.UTF_8))));
+    }
+
+    @Test
+    void testResolveVersionFromResource_NullStream() {
+        Assertions.assertEquals(Version.UNKNOWN, Version.resolveVersionFromResource(null));
+    }
+
+    @Test
+    void testResolveVersionFromResource_UnreadableStream() {
+        InputStream broken =
+                new InputStream() {
+                    @Override
+                    public int read() throws IOException {
+                        throw new IOException("boom");
+                    }
+                };
+        Assertions.assertEquals(Version.UNKNOWN, Version.resolveVersionFromResource(broken));
+    }
+
+    @Test
+    void testResolveVersionFrom_Normal() {
+        Properties props = new Properties();
+        props.setProperty("version", "  2.0.3-SNAPSHOT  ");
+        Assertions.assertEquals("2.0.3-SNAPSHOT", Version.resolveVersionFrom(props));
+    }
+
+    @Test
+    void testResolveVersionFrom_UnfilteredPlaceholder() {
+        Properties props = new Properties();
+        props.setProperty("version", "${project.version}");
+        Assertions.assertEquals(Version.UNKNOWN, Version.resolveVersionFrom(props));
+    }
+
+    @Test
+    void testResolveVersionFrom_NullValue() {
+        Properties props = new Properties();
+        Assertions.assertEquals(Version.UNKNOWN, Version.resolveVersionFrom(props));
+    }
+
+    @Test
+    void testResolveVersionFrom_BlankValue() {
+        Properties props = new Properties();
+        props.setProperty("version", "   ");
+        Assertions.assertEquals(Version.UNKNOWN, Version.resolveVersionFrom(props));
+    }
+
+    @Test
+    void testResolveVersionFrom_NullProps() {
+        Assertions.assertEquals(Version.UNKNOWN, Version.resolveVersionFrom(null));
+    }
+
+    @Test
+    void testResolveVersionFromManifest_Normal() {
+        Assertions.assertEquals(
+                "2.0.3-SNAPSHOT", Version.resolveVersionFromManifest("2.0.3-SNAPSHOT"));
+    }
+
+    @Test
+    void testResolveVersionFromManifest_Trimmed() {
+        Assertions.assertEquals(
+                "2.0.3-SNAPSHOT", Version.resolveVersionFromManifest("  2.0.3-SNAPSHOT  "));
+    }
+
+    @Test
+    void testResolveVersionFromManifest_Null() {
+        Assertions.assertEquals(Version.UNKNOWN, Version.resolveVersionFromManifest(null));
+    }
+
+    @Test
+    void testResolveVersionFromManifest_Blank() {
+        Assertions.assertEquals(Version.UNKNOWN, Version.resolveVersionFromManifest("   "));
+    }
+
+    @Test
+    void testResolveVersionFromManifest_UnfilteredPlaceholder() {
+        Assertions.assertEquals(
+                Version.UNKNOWN, Version.resolveVersionFromManifest("${project.version}"));
     }
 
     @Test

--- a/agentscope-core/src/test/resources/agentscope-test-version.properties
+++ b/agentscope-core/src/test/resources/agentscope-test-version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
+        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
@@ -331,6 +332,22 @@
                         <phase>package</phase>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <!-- Record the resolved ${project.version} in the jar manifest so
+                                 Version can fall back to Implementation-Version when the filtered
+                                 version.properties resource is absent from the classpath (e.g.
+                                 shaded/relocated jars or custom packaging). -->
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes #3086

## AgentScope-Java Version

2.0.3

## Description

### Background

`Version.VERSION` was a hardcoded constant (`1.0.13-SNAPSHOT`) that had
drifted from the actual Maven project version (`2.0.3-SNAPSHOT` in `pom.xml`
via the CI-friendly `<revision>` property), so callers of the `Version` API
could receive a stale version string at runtime.

### Purpose

Make Maven `<revision>` the single source of truth for the runtime version,
eliminating manual synchronization between `pom.xml` and `Version.java`.

### Changes

- `agentscope-core/src/main/resources/META-INF/agentscope/version.properties`
  (new): filtered with `${project.version}` during the build
- `agentscope-core/src/main/java/io/agentscope/core/Version.java`: load
  `VERSION` from the classpath resource at runtime; fall back to `"unknown"`
  if an unfiltered build leaks the literal `${` placeholder
- `agentscope-core/pom.xml`: enable resource filtering for the version
  properties file only; keep all other resources unfiltered
- `agentscope-core/src/test/resources/agentscope-test-version.properties`
  (new): test-only filtered resource for cross-verification
- `agentscope-core/src/test/java/io/agentscope/core/VersionTest.java`: assert
  `Version.VERSION` equals the Maven-resolved version and matches
  semantic-versioning; gracefully skip under non-Maven (IDEA) builds

### How to test

```
mvn -pl agentscope-core test -Dtest=VersionTest
mvn -pl agentscope-core clean verify
```

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`) — pending CI confirmation
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (N/A — no doc changes in this PR)
- [x] Code is ready for review
