### PR TITLE
fix(memory): rebuild curated memory from all ledgers when MEMORY.md is blank

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryConsolidator.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryConsolidator.java
@@ -152,12 +152,29 @@ public class MemoryConsolidator {
      * advances the watermark on success.
      *
      * <p>If no daily files have been touched since the last run, this is a no-op.
+     *
+     * <p>If the curated MEMORY.md is blank while a watermark exists (e.g. the file was
+     * deleted or cleared without removing {@code memory/.consolidation_state}), the
+     * watermark is ignored for that run and all daily ledgers are consolidated again —
+     * rebuilding MEMORY.md from the full ledger history instead of silently dropping
+     * every day before the watermark.
      */
     public Mono<Void> consolidate(RuntimeContext rc) {
         Instant watermark = readWatermark(rc);
         Instant runStart = Instant.now();
 
         String currentMemory = workspaceManager.readMemoryMd(rc);
+        // A blank curated MEMORY.md with an advanced watermark means the view was lost or
+        // cleared without resetting the watermark: merging only post-watermark ledgers into
+        // "(empty)" would silently drop every older day from the curated file. Rebuild from
+        // the full ledger history instead — the same input assembly as a first run.
+        if (currentMemory.isBlank() && !watermark.equals(Instant.EPOCH)) {
+            log.warn(
+                    "MEMORY.md is blank while a consolidation watermark exists ({}) — rebuilding"
+                            + " from all daily ledgers",
+                    watermark);
+            watermark = Instant.EPOCH;
+        }
         String dailyEntries = readDailyEntries(rc, watermark);
 
         if (dailyEntries.isBlank()) {

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryConsolidatorFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryConsolidatorFilesystemTest.java
@@ -20,16 +20,24 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.ToolSchema;
 import io.agentscope.harness.agent.filesystem.remote.RemoteFilesystem;
 import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
 
 /**
  * Verifies that {@link MemoryConsolidator} reads daily ledgers and writes watermark / MEMORY.md
@@ -148,5 +156,175 @@ class MemoryConsolidatorFilesystemTest {
         assertTrue(
                 Files.exists(localState),
                 "state file should be written to local disk when no filesystem is configured");
+    }
+
+    // ======================================================================
+    // consolidate: a blank MEMORY.md with an advanced watermark must rebuild
+    // from ALL daily ledgers instead of merging only post-watermark entries
+    // into "(empty)" — which silently drops every older day from the file
+    // ======================================================================
+
+    @Test
+    void consolidate_rebuildsFromAllLedgersWhenMemoryMdBlank(@TempDir Path tmp) throws Exception {
+        InMemoryStore store = new InMemoryStore();
+        List<String> ns = List.of("test-ns");
+        RemoteFilesystem fs = new RemoteFilesystem(store, ns);
+        RecordingModel model = new RecordingModel("# rebuilt curated memory");
+        Instant watermark = Instant.parse("2025-06-15T12:00:00Z");
+        try (WorkspaceManager wsm = new WorkspaceManager(tmp, fs)) {
+            seedStoreFile(
+                    store,
+                    ns,
+                    "memory/2025-06-14.md",
+                    "older day facts",
+                    watermark.minusSeconds(3600));
+            seedStoreFile(
+                    store,
+                    ns,
+                    "memory/2025-06-16.md",
+                    "fresh day facts",
+                    watermark.plusSeconds(3600));
+            wsm.writeUtf8WorkspaceRelative(
+                    RuntimeContext.empty(),
+                    MemoryConsolidator.STATE_REL_PATH,
+                    watermark.toString());
+
+            MemoryConsolidator consolidator = new MemoryConsolidator(wsm, model);
+            consolidator.consolidate(RuntimeContext.empty()).block();
+
+            String userPrompt = model.userPrompt(0);
+            assertTrue(userPrompt.contains("### 2025-06-14.md"), "older ledger must be included");
+            assertTrue(userPrompt.contains("### 2025-06-16.md"));
+            assertTrue(userPrompt.contains("(empty)"));
+            // a full rebuild must not label the input as an incremental merge
+            assertFalse(userPrompt.contains("(since "));
+
+            assertEquals("# rebuilt curated memory", wsm.readMemoryMd(RuntimeContext.empty()));
+            assertTrue(consolidator.readWatermark(RuntimeContext.empty()).isAfter(watermark));
+        }
+    }
+
+    @Test
+    void consolidate_rebuildsEvenWithoutFreshLedgersWhenMemoryMdBlank(@TempDir Path tmp)
+            throws Exception {
+        InMemoryStore store = new InMemoryStore();
+        List<String> ns = List.of("test-ns");
+        RemoteFilesystem fs = new RemoteFilesystem(store, ns);
+        RecordingModel model = new RecordingModel("# rebuilt");
+        Instant watermark = Instant.parse("2025-06-15T12:00:00Z");
+        try (WorkspaceManager wsm = new WorkspaceManager(tmp, fs)) {
+            seedStoreFile(
+                    store,
+                    ns,
+                    "memory/2025-06-14.md",
+                    "older day facts",
+                    watermark.minusSeconds(3600));
+            wsm.writeUtf8WorkspaceRelative(
+                    RuntimeContext.empty(),
+                    MemoryConsolidator.STATE_REL_PATH,
+                    watermark.toString());
+
+            MemoryConsolidator consolidator = new MemoryConsolidator(wsm, model);
+            consolidator.consolidate(RuntimeContext.empty()).block();
+
+            assertEquals(1, model.inputs.size());
+            assertTrue(model.userPrompt(0).contains("### 2025-06-14.md"));
+        }
+    }
+
+    @Test
+    void consolidate_keepsIncrementalMergeWhenMemoryMdPresent(@TempDir Path tmp) throws Exception {
+        InMemoryStore store = new InMemoryStore();
+        List<String> ns = List.of("test-ns");
+        RemoteFilesystem fs = new RemoteFilesystem(store, ns);
+        RecordingModel model = new RecordingModel("# merged");
+        Instant watermark = Instant.parse("2025-06-15T12:00:00Z");
+        try (WorkspaceManager wsm = new WorkspaceManager(tmp, fs)) {
+            seedStoreFile(
+                    store,
+                    ns,
+                    "memory/2025-06-14.md",
+                    "older day facts",
+                    watermark.minusSeconds(3600));
+            seedStoreFile(
+                    store,
+                    ns,
+                    "memory/2025-06-16.md",
+                    "fresh day facts",
+                    watermark.plusSeconds(3600));
+            wsm.writeUtf8WorkspaceRelative(
+                    RuntimeContext.empty(), "MEMORY.md", "existing curated view");
+            wsm.writeUtf8WorkspaceRelative(
+                    RuntimeContext.empty(),
+                    MemoryConsolidator.STATE_REL_PATH,
+                    watermark.toString());
+
+            MemoryConsolidator consolidator = new MemoryConsolidator(wsm, model);
+            consolidator.consolidate(RuntimeContext.empty()).block();
+
+            String userPrompt = model.userPrompt(0);
+            assertTrue(userPrompt.contains("existing curated view"));
+            assertTrue(userPrompt.contains("### 2025-06-16.md"));
+            assertFalse(userPrompt.contains("### 2025-06-14.md"));
+            assertTrue(userPrompt.contains("(since " + watermark));
+        }
+    }
+
+    @Test
+    void consolidate_skipsWhenViewPresentAndNoFreshLedgers(@TempDir Path tmp) throws Exception {
+        InMemoryStore store = new InMemoryStore();
+        List<String> ns = List.of("test-ns");
+        RemoteFilesystem fs = new RemoteFilesystem(store, ns);
+        RecordingModel model = new RecordingModel("# merged");
+        Instant watermark = Instant.parse("2025-06-15T12:00:00Z");
+        try (WorkspaceManager wsm = new WorkspaceManager(tmp, fs)) {
+            seedStoreFile(
+                    store,
+                    ns,
+                    "memory/2025-06-14.md",
+                    "older day facts",
+                    watermark.minusSeconds(3600));
+            wsm.writeUtf8WorkspaceRelative(
+                    RuntimeContext.empty(), "MEMORY.md", "existing curated view");
+            wsm.writeUtf8WorkspaceRelative(
+                    RuntimeContext.empty(),
+                    MemoryConsolidator.STATE_REL_PATH,
+                    watermark.toString());
+
+            MemoryConsolidator consolidator = new MemoryConsolidator(wsm, model);
+            consolidator.consolidate(RuntimeContext.empty()).block();
+
+            assertEquals(0, model.inputs.size());
+        }
+    }
+
+    private static final class RecordingModel implements Model {
+
+        private final List<List<Msg>> inputs = new ArrayList<>();
+        private final String response;
+
+        RecordingModel(String response) {
+            this.response = response;
+        }
+
+        @Override
+        public Flux<ChatResponse> stream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            inputs.add(List.copyOf(messages));
+            return Flux.just(
+                    ChatResponse.builder()
+                            .id("consolidation-response")
+                            .content(List.of(TextBlock.builder().text(response).build()))
+                            .build());
+        }
+
+        @Override
+        public String getModelName() {
+            return "recording-model";
+        }
+
+        String userPrompt(int index) {
+            return ((TextBlock) inputs.get(index).get(1).getContent().get(0)).getText();
+        }
     }
 }


### PR DESCRIPTION
Closes #3090

## 问题

`MemoryConsolidator` 每次合并的输入组装是"当前 MEMORY.md（或 `(empty)`）+ 水位之后严格修改的账本"，用模型输出覆写 MEMORY.md，然后推进水位。它从不校验 MEMORY.md 是否承载着此前合并保留下来的长期记忆。

当 MEMORY.md 缺失或为空而水位文件还在时——手动清理、误删等——下一次合并会把"仅剩的水位后账本"合并进空视图并覆写文件：水位之前未再次修改的旧账本不参与重建，整个过程没有针对该状态的告警。

## 修复

在 `consolidate()` 中：策划视图空白而水位已存在时，记一条警告并把本次运行的水位按 `EPOCH` 处理——与首次运行相同的输入组装。`(since ...)` 提示词标签与账本过滤共用同一个变量，自动消失。Javadoc 已补充说明重建行为。

各状态下的行为对照：

| 状态 | 修复前 | 修复后 |
|---|---|---|
| 视图存在，有新账本 | 增量合并 | 不变 |
| 视图存在，无新账本 | 跳过 | 不变 |
| 无水位（首次运行） | 全部账本 | 不变 |
| **视图缺失或为空，水位存在** | **把水位后账本合并进 `(empty)`——旧账本不参与** | **警告 + 从全部可用账本重建** |

修复后的语义：当 MEMORY.md 缺失或为空且已有合并水位时，本次合并重新纳入全部可用账本。这会**重新生成**记忆摘要，不保证还原原文件；人工补充过、或已无对应账本的内容可能无法恢复。

## 限制

- 读取错误无法与空文件区分：MEMORY.md 的瞬时读取失败同样会触发重建路径（见 issue 的"相关问题"）。
- 部分账本读取失败尚未阻止合并继续执行。
- 全量输入可能超出模型上下文限制：consolidation 提示词已带输出侧的 token 预算约束，但输入侧没有截断。

## 测试

- `MemoryConsolidatorFilesystemTest` 9 项全部通过，其中新增 4 项：
  - `consolidate_rebuildsFromAllLedgersWhenMemoryMdBlank`——水位前、水位后的账本都进入模型输入，无 `(since ...)` 标签，MEMORY.md 写入模型输出，水位正常推进
  - `consolidate_rebuildsEvenWithoutFreshLedgersWhenMemoryMdBlank`——水位后没有新提取也能重建丢失的视图（修复前会跳过，旧账本永远不参与）
  - `consolidate_keepsIncrementalMergeWhenMemoryMdPresent`——增量合并行为不变
  - `consolidate_skipsWhenViewPresentAndNoFreshLedgers`——跳过行为不变
- `agentscope-harness` 模块全量 2335 项：除 2 项既有错误外全部通过（`DangerousPathBypassTest` 的 2 个 symlink 用例需要 Windows 管理员特权，属环境限制，与本改动无关）。
- 等效的重建语义已在下游部署中完成端到端验证：删除 MEMORY.md 后，下一次合并自动从全部账本重建。

## 开放问题

全量重建会把整个账本历史在一次调用中发给 LLM，token 开销高于增量合并；替代方案是检测到该状态时跳过并告警。选用重建的理由：每日账本是事实源头、MEMORY.md 是派生视图，目前对丢失的视图没有任何恢复机制；代价是重建调用更重，且输出是重新生成的摘要而非原文件还原。如果维护者倾向更保守的行为，可以随时调整。
