### PR TITLE
fix(harness): defer self-managed sandbox shutdown until session mirro…

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/PinnedSandboxFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/PinnedSandboxFilesystem.java
@@ -28,14 +28,22 @@ import java.util.Objects;
  * must not unpin this mirror filesystem.
  *
  * <p>Safe for DataAgent-style <em>user-managed</em> sandboxes that stay alive across
- * acquire/release. Self-managed sandboxes that stop on release may still fail if the async upload
- * races past shutdown.
+ * acquire/release. For self-managed sandboxes, pair with {@link
+ * io.agentscope.harness.agent.sandbox.SandboxMirrorReleaseCoordinator} so call teardown defers
+ * {@code stop}/{@code shutdown} until outstanding pinned mirror tasks finish.
  */
 public final class PinnedSandboxFilesystem extends SandboxBackedFilesystem {
 
     public PinnedSandboxFilesystem(Sandbox sandbox) {
         Objects.requireNonNull(sandbox, "sandbox");
         super.setSandbox(sandbox);
+    }
+
+    @Override
+    protected boolean softFailWhenStopped() {
+        // Async mirrors must not crash the mirror thread when call teardown already stopped the
+        // sandbox; sync tool paths keep the hard-fail default on SandboxBackedFilesystem.
+        return true;
     }
 
     @Override

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystem.java
@@ -61,6 +61,14 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
 
     private static final Logger log = LoggerFactory.getLogger(SandboxBackedFilesystem.class);
 
+    /**
+     * Shared message for a missing or already-stopped sandbox. Matches {@link
+     * #requireSandbox(RuntimeContext)} so async mirrors degrade to the same warn text instead of
+     * NPE after {@code stop}/{@code shutdown}.
+     */
+    static final String NO_ACTIVE_SANDBOX_MESSAGE =
+            "No active sandbox — sandbox filesystem used outside of a call context";
+
     private final String fsId;
     private volatile Sandbox sandbox;
 
@@ -122,7 +130,14 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
     @Override
     public List<FileUploadResponse> uploadFiles(
             RuntimeContext runtimeContext, List<Map.Entry<String, byte[]>> files) {
-        Sandbox active = requireSandbox(runtimeContext);
+        Sandbox active = resolveSandboxForTransfer(runtimeContext);
+        if (active == null) {
+            List<FileUploadResponse> failed = new ArrayList<>(files.size());
+            for (Map.Entry<String, byte[]> file : files) {
+                failed.add(FileUploadResponse.fail(file.getKey(), NO_ACTIVE_SANDBOX_MESSAGE));
+            }
+            return failed;
+        }
         List<FileUploadResponse> results = new ArrayList<>(files.size());
 
         for (Map.Entry<String, byte[]> file : files) {
@@ -177,7 +192,14 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
     @Override
     public List<FileDownloadResponse> downloadFiles(
             RuntimeContext runtimeContext, List<String> paths) {
-        Sandbox active = requireSandbox(runtimeContext);
+        Sandbox active = resolveSandboxForTransfer(runtimeContext);
+        if (active == null) {
+            List<FileDownloadResponse> failed = new ArrayList<>(paths.size());
+            for (String path : paths) {
+                failed.add(FileDownloadResponse.fail(path, NO_ACTIVE_SANDBOX_MESSAGE));
+            }
+            return failed;
+        }
         List<FileDownloadResponse> results = new ArrayList<>(paths.size());
 
         for (String path : paths) {
@@ -248,10 +270,35 @@ public class SandboxBackedFilesystem extends BaseSandboxFilesystem implements Sa
             s = sandbox;
         }
         if (s == null) {
-            throw new SandboxException.SandboxConfigurationException(
-                    "No active sandbox — sandbox filesystem used outside of a call context");
+            throw new SandboxException.SandboxConfigurationException(NO_ACTIVE_SANDBOX_MESSAGE);
         }
         return s;
+    }
+
+    /**
+     * Like {@link #requireSandbox}, but when the bound sandbox has already stopped: soft-fail
+     * callers ({@link #softFailWhenStopped()} {@code true}, i.e. pinned async mirrors) get {@code
+     * null} after a warn; hard-fail callers (default sync tool path) still throw.
+     */
+    private Sandbox resolveSandboxForTransfer(RuntimeContext runtimeContext) {
+        Sandbox s = requireSandbox(runtimeContext);
+        if (!s.isRunning()) {
+            if (softFailWhenStopped()) {
+                log.warn("[sandbox-fs] {}", NO_ACTIVE_SANDBOX_MESSAGE);
+                return null;
+            }
+            throw new SandboxException.SandboxConfigurationException(NO_ACTIVE_SANDBOX_MESSAGE);
+        }
+        return s;
+    }
+
+    /**
+     * Whether upload/download should soft-fail when the bound sandbox is present but already
+     * stopped. Default {@code false} keeps synchronous tool calls loud; {@link
+     * PinnedSandboxFilesystem} overrides to {@code true} for async session mirrors.
+     */
+    protected boolean softFailWhenStopped() {
+        return false;
     }
 
     private String shellSingleQuote(String s) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/session/SessionTree.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/session/SessionTree.java
@@ -21,7 +21,9 @@ import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.model.ReadResult;
 import io.agentscope.harness.agent.filesystem.sandbox.PinnedSandboxFilesystem;
 import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxAcquireResult;
 import io.agentscope.harness.agent.sandbox.SandboxAware;
+import io.agentscope.harness.agent.sandbox.SandboxMirrorReleaseCoordinator;
 import io.agentscope.harness.agent.transcript.ObjectStoreTranscriptStore;
 import io.agentscope.harness.agent.transcript.TranscriptRef;
 import io.agentscope.harness.agent.transcript.TranscriptStore;
@@ -112,9 +114,15 @@ public class SessionTree {
      * @return {@code true} if the mirrors quiesced within the timeout
      */
     public static boolean awaitMirrorQuiescence(long timeout, TimeUnit unit) {
+        long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
         try {
-            MIRROR_EXECUTOR.submit(() -> {}).get(timeout, unit);
-            return true;
+            long mirrorWaitNanos = Math.max(0L, deadlineNanos - System.nanoTime());
+            MIRROR_EXECUTOR.submit(() -> {}).get(mirrorWaitNanos, TimeUnit.NANOSECONDS);
+            // Deferred stop/shutdown runs on a separate executor; drain it too so graceful close
+            // does not race sandbox teardown that was scheduled from mirror finally blocks.
+            long releaseWaitNanos = Math.max(0L, deadlineNanos - System.nanoTime());
+            return SandboxMirrorReleaseCoordinator.awaitReleaseQuiescence(
+                    releaseWaitNanos, TimeUnit.NANOSECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             return false;
@@ -550,7 +558,7 @@ public class SessionTree {
         if (transcriptStore == null || transcriptRef == null || entries.isEmpty()) {
             return;
         }
-        // Same pin as scheduleMirror: async segment upload must survive call unbind.
+        // Prepare work before retain so a failure here cannot leak a deferred sandbox release.
         final AbstractFilesystem mirrorFs = pinIfSandbox(filesystem);
         final TranscriptStore store = transcriptStoreForMirror(mirrorFs);
         final TranscriptRef ref = transcriptRef;
@@ -558,9 +566,10 @@ public class SessionTree {
         for (SessionEntry entry : entries) {
             sb.append(JsonUtils.getJsonCodec().toJson(entry)).append('\n');
         }
-        byte[] payload = sb.toString().getBytes(StandardCharsets.UTF_8);
-        String wid = writerId;
-        MIRROR_EXECUTOR.execute(
+        final byte[] payload = sb.toString().getBytes(StandardCharsets.UTF_8);
+        final String wid = writerId;
+        submitPinnedMirror(
+                mirrorFs,
                 () -> {
                     try {
                         store.appendSegment(ref, seqStart, seqEnd, wid, payload);
@@ -584,10 +593,12 @@ public class SessionTree {
         if (filesystem == null || workspaceRoot == null) {
             return;
         }
+        // Resolve paths before retain so retain↔execute has no prepare-side leak window.
         final AbstractFilesystem mirrorFs = pinIfSandbox(filesystem);
         final String contextRel = resolveRelativePath(contextFile);
         final String logRel = resolveRelativePath(logFile);
-        MIRROR_EXECUTOR.execute(
+        submitPinnedMirror(
+                mirrorFs,
                 () -> {
                     mirrorToFilesystem(mirrorFs, contextFile, contextRel);
                     mirrorToFilesystem(mirrorFs, logFile, logRel);
@@ -595,17 +606,75 @@ public class SessionTree {
     }
 
     /**
-     * When {@code fs} is a call-scoped sandbox proxy with an active binding, return a pinned
-     * filesystem that keeps that sandbox for async uploads. Otherwise return {@code fs} as-is.
+     * Retains a pinned sandbox (if any), submits {@code task} to the mirror executor, and always
+     * pairs {@code releaseMirror} — either in the task {@code finally} or immediately when
+     * submission itself fails.
      */
-    private static AbstractFilesystem pinIfSandbox(AbstractFilesystem fs) {
-        if (fs instanceof SandboxAware aware) {
-            Sandbox sb = aware.getSandbox();
-            if (sb != null) {
-                return new PinnedSandboxFilesystem(sb);
+    private static void submitPinnedMirror(AbstractFilesystem mirrorFs, Runnable task) {
+        final Sandbox retainedSandbox = sandboxForMirrorRetain(mirrorFs);
+        if (retainedSandbox != null) {
+            SandboxMirrorReleaseCoordinator.retain(retainedSandbox);
+        }
+        try {
+            MIRROR_EXECUTOR.execute(
+                    () -> {
+                        try {
+                            task.run();
+                        } finally {
+                            if (retainedSandbox != null) {
+                                SandboxMirrorReleaseCoordinator.releaseMirror(retainedSandbox);
+                            }
+                        }
+                    });
+        } catch (RuntimeException e) {
+            if (retainedSandbox != null) {
+                SandboxMirrorReleaseCoordinator.releaseMirror(retainedSandbox);
             }
+            throw e;
+        }
+    }
+
+    /**
+     * When {@code fs} is a sandbox-backed filesystem, return a pinned filesystem that keeps the
+     * <em>per-call</em> sandbox for async uploads. Prefers {@link SandboxAcquireResult} on {@link
+     * #fsRc} (issue #2490) over the legacy shared {@link SandboxAware#getSandbox()} field, which
+     * is last-writer-wins under concurrent distinct sessions.
+     */
+    private AbstractFilesystem pinIfSandbox(AbstractFilesystem fs) {
+        Sandbox sb = resolveSandboxForPin(fs);
+        if (sb != null) {
+            return new PinnedSandboxFilesystem(sb);
         }
         return fs;
+    }
+
+    /**
+     * Resolves the sandbox to pin for an async mirror: per-call {@link RuntimeContext} binding
+     * first, then the shared {@link SandboxAware} fallback for context-free callers.
+     */
+    private Sandbox resolveSandboxForPin(AbstractFilesystem fs) {
+        RuntimeContext rc = fsRc;
+        if (rc != null) {
+            SandboxAcquireResult bound = rc.get(SandboxAcquireResult.class);
+            if (bound != null && bound.getSandbox() != null) {
+                return bound.getSandbox();
+            }
+        }
+        if (fs instanceof SandboxAware aware) {
+            return aware.getSandbox();
+        }
+        return null;
+    }
+
+    /**
+     * Returns the sandbox pinned for an async mirror task, or {@code null} when the mirror does
+     * not hold a sandbox connection that must defer self-managed release.
+     */
+    private static Sandbox sandboxForMirrorRetain(AbstractFilesystem mirrorFs) {
+        if (mirrorFs instanceof PinnedSandboxFilesystem pinned) {
+            return pinned.getSandbox();
+        }
+        return null;
     }
 
     private TranscriptStore transcriptStoreForMirror(AbstractFilesystem mirrorFs) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/middleware/SandboxLifecycleMiddleware.java
@@ -21,6 +21,7 @@ import io.agentscope.harness.agent.sandbox.Sandbox;
 import io.agentscope.harness.agent.sandbox.SandboxAcquireResult;
 import io.agentscope.harness.agent.sandbox.SandboxContext;
 import io.agentscope.harness.agent.sandbox.SandboxManager;
+import io.agentscope.harness.agent.sandbox.SandboxMirrorReleaseCoordinator;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,10 +40,12 @@ import org.slf4j.LoggerFactory;
  *
  * <h2>doFinally</h2>
  * <ol>
+ *   <li>Clear this call's session binding from the {@link RuntimeContext} (and the filesystem
+ *       proxy fallback) so concurrent calls cannot observe a stale binding</li>
  *   <li>Persist sandbox session state via {@link SandboxManager} and
  *       {@link io.agentscope.harness.agent.sandbox.SessionSandboxStateStore}</li>
- *   <li>Release the session via {@link SandboxManager} (stop + optional shutdown)</li>
- *   <li>Clear this call's session binding from the {@link RuntimeContext}</li>
+ *   <li>Request release via {@link SandboxMirrorReleaseCoordinator} (defers stop/shutdown while
+ *       session mirrors still need the connection; otherwise releases immediately)</li>
  * </ol>
  *
  * <p>Post-call failures (persist, release) are logged but do not propagate — this ensures
@@ -51,7 +54,9 @@ import org.slf4j.LoggerFactory;
  * <p>The sandbox is bound <em>per call</em> on the invocation's {@link RuntimeContext} rather than
  * on a shared agent-level slot: distinct {@code (userId, sessionId)} sessions run in parallel on
  * the same agent bean, so a shared slot would let concurrent calls corrupt each other's binding
- * (issue #2490).
+ * (issue #2490). {@link SandboxMirrorReleaseCoordinator#requestRelease} always closes the acquire
+ * result's lease ({@link io.agentscope.harness.agent.sandbox.SandboxLease#noop()} when no guard
+ * is configured).
  */
 public class SandboxLifecycleMiddleware implements HarnessRuntimeMiddleware {
 
@@ -126,14 +131,14 @@ public class SandboxLifecycleMiddleware implements HarnessRuntimeMiddleware {
                 ctx.put(SandboxAcquireResult.class, null);
                 filesystemProxy.clearSandboxIfCurrent(sandbox);
                 try {
-                    sandboxManager.release(result);
+                    // No mirrors can be pending before start succeeds; release immediately.
+                    SandboxMirrorReleaseCoordinator.requestRelease(sandboxManager, result);
                 } catch (Exception releaseErr) {
                     log.warn(
                             "[sandbox-mw] Failed to release session after pre-call failure: {}",
                             releaseErr.getMessage(),
                             releaseErr);
                 }
-                result.getLease().close();
                 throw e;
             }
         } catch (Exception e) {
@@ -169,10 +174,11 @@ public class SandboxLifecycleMiddleware implements HarnessRuntimeMiddleware {
             log.warn("[sandbox-mw] Failed to persist sandbox state: {}", e.getMessage(), e);
         }
         try {
-            sandboxManager.release(result);
+            // Hand destructive stop/shutdown (and lease close) to outstanding session mirrors
+            // when present; otherwise release immediately. Call binding is already cleared above.
+            SandboxMirrorReleaseCoordinator.requestRelease(sandboxManager, result);
         } catch (Exception e) {
             log.warn("[sandbox-mw] Failed to release sandbox session: {}", e.getMessage(), e);
         }
-        result.getLease().close();
     }
 }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxMirrorReleaseCoordinator.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/sandbox/SandboxMirrorReleaseCoordinator.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.sandbox;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Defers self-managed sandbox {@code stop}/{@code shutdown} until asynchronous session mirrors
+ * that still need the live connection have finished.
+ *
+ * <p>Call-scoped binding is still cleared immediately by the lifecycle middleware. Only the
+ * destructive release (and its {@link SandboxLease}) is handed off when mirror tasks remain.
+ *
+ * <p>Deferred {@code stop}/{@code shutdown} runs on a dedicated daemon executor so slow sandbox
+ * teardown does not block the session-tree mirror thread.
+ *
+ * <p>{@link #requestRelease} always closes {@link SandboxAcquireResult#getLease()}: the acquire
+ * result guarantees a non-null lease ({@link SandboxLease#noop()} when no guard is configured),
+ * including {@link SandboxAcquireResult#userManaged} paths where {@link SandboxManager#release}
+ * is a no-op.
+ *
+ * <p>When multiple concurrent calls share one self-managed sandbox instance, each call's {@link
+ * #requestRelease} is queued separately and flushed when outstanding mirrors drain — one entry
+ * per call, not last-writer-wins.
+ *
+ * <p>Usage:
+ *
+ * <ol>
+ *   <li>{@link #retain(Sandbox)} once per scheduled mirror task that pins the sandbox
+ *   <li>{@link #requestRelease(SandboxManager, SandboxAcquireResult)} from call teardown
+ *   <li>{@link #releaseMirror(Sandbox)} in the mirror task {@code finally} block
+ * </ol>
+ */
+public final class SandboxMirrorReleaseCoordinator {
+
+    private static final Logger log =
+            LoggerFactory.getLogger(SandboxMirrorReleaseCoordinator.class);
+
+    private static final SandboxMirrorReleaseCoordinator INSTANCE =
+            new SandboxMirrorReleaseCoordinator();
+
+    /**
+     * Serialises deferred sandbox destruction off the mirror upload thread so a slow
+     * {@code stop}/{@code shutdown} cannot head-of-line block other session mirrors.
+     */
+    private static final ExecutorService RELEASE_EXECUTOR =
+            Executors.newSingleThreadExecutor(
+                    r -> {
+                        Thread t = new Thread(r, "sandbox-mirror-release");
+                        t.setDaemon(true);
+                        return t;
+                    });
+
+    private final Object lock = new Object();
+    private final IdentityHashMap<Sandbox, State> states = new IdentityHashMap<>();
+
+    private SandboxMirrorReleaseCoordinator() {}
+
+    /**
+     * Increments the outstanding-mirror count for {@code sandbox}. Call once for each async
+     * mirror task that will use the pinned sandbox connection.
+     *
+     * @param sandbox sandbox retained for a mirror task; ignored when {@code null}
+     */
+    public static void retain(Sandbox sandbox) {
+        if (sandbox == null) {
+            return;
+        }
+        INSTANCE.doRetain(sandbox);
+    }
+
+    /**
+     * Decrements the outstanding-mirror count. When the count reaches zero and call teardown
+     * already requested release, schedules {@link SandboxManager#release} and lease close on the
+     * dedicated release executor for every deferred call result.
+     *
+     * @param sandbox sandbox previously passed to {@link #retain(Sandbox)}
+     */
+    public static void releaseMirror(Sandbox sandbox) {
+        if (sandbox == null) {
+            return;
+        }
+        INSTANCE.doReleaseMirror(sandbox);
+    }
+
+    /**
+     * Requests destruction of a call-acquired sandbox. Self-managed sandboxes with outstanding
+     * mirrors defer {@code stop}/{@code shutdown} and lease close until {@link #releaseMirror}
+     * drains the count. User-managed sandboxes always release immediately (manager no-ops
+     * shutdown).
+     *
+     * <p>When there are no outstanding mirrors, release runs synchronously on the caller thread
+     * (same as the historical call-teardown path). A tombstone marks the sandbox as already
+     * released so a late {@link #retain} cannot leave {@code pendingMirrors > 0} with an empty
+     * deferred list and silently skip destruction.
+     *
+     * <p>When mirrors are pending, each call's acquire result is appended to the deferred list so
+     * shared-sandbox concurrent calls each get {@code release} + lease close.
+     *
+     * @param manager sandbox manager that owns stop/shutdown
+     * @param result acquire result from the finishing call
+     */
+    public static void requestRelease(SandboxManager manager, SandboxAcquireResult result) {
+        if (manager == null || result == null || result.getSandbox() == null) {
+            return;
+        }
+        INSTANCE.doRequestRelease(manager, result);
+    }
+
+    /**
+     * Blocks until deferred release tasks submitted before this call have finished.
+     *
+     * <p>Intended to pair with mirror quiescence during graceful shutdown: mirror drain schedules
+     * deferred releases, then this barrier waits for those destructions to complete.
+     *
+     * @param timeout maximum time to wait
+     * @param unit time unit of {@code timeout}
+     * @return {@code true} if deferred releases quiesced within the timeout
+     */
+    public static boolean awaitReleaseQuiescence(long timeout, TimeUnit unit) {
+        try {
+            RELEASE_EXECUTOR.submit(() -> {}).get(timeout, unit);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        } catch (Exception e) {
+            log.debug("awaitReleaseQuiescence did not complete cleanly: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Drops all retained / deferred state.
+     *
+     * <p>Intended for unit tests that share the process-wide coordinator.
+     */
+    public static void resetForTests() {
+        synchronized (INSTANCE.lock) {
+            INSTANCE.states.clear();
+        }
+    }
+
+    /**
+     * Test-only: forces {@code pendingMirrors == 0} while keeping any existing registration (and
+     * deferred release if present), so the next {@link #releaseMirror} hits the underflow path.
+     */
+    static void forcePendingZeroForUnderflowTests(Sandbox sandbox) {
+        synchronized (INSTANCE.lock) {
+            State state = INSTANCE.states.get(sandbox);
+            if (state == null) {
+                throw new IllegalStateException("expected state for " + sandbox);
+            }
+            state.pendingMirrors = 0;
+        }
+    }
+
+    private void doRetain(Sandbox sandbox) {
+        synchronized (lock) {
+            State state = states.computeIfAbsent(sandbox, ignored -> new State());
+            if (state.released) {
+                log.error(
+                        "[sandbox-mirror-release] late retain after sandbox already released;"
+                                + " pairing only — connection will not be kept alive");
+            }
+            state.pendingMirrors++;
+        }
+    }
+
+    private void doReleaseMirror(Sandbox sandbox) {
+        List<DeferredRelease> toFlush = null;
+        boolean clearTombstone = false;
+        synchronized (lock) {
+            State state = states.get(sandbox);
+            if (state == null) {
+                return;
+            }
+            state.pendingMirrors--;
+            if (state.pendingMirrors < 0) {
+                // Pairing bug: clamp and take over any deferred releases so leases are not
+                // silently orphaned.
+                log.error(
+                        "[sandbox-mirror-release] pending mirror count went negative for sandbox;"
+                                + " taking over deferred releases if present");
+                state.pendingMirrors = 0;
+                if (!state.deferred.isEmpty()) {
+                    toFlush = takeDeferred(state);
+                    state.released = true;
+                    states.remove(sandbox);
+                } else {
+                    states.remove(sandbox);
+                }
+            } else if (state.pendingMirrors == 0) {
+                if (!state.deferred.isEmpty()) {
+                    toFlush = takeDeferred(state);
+                    state.released = true;
+                    states.remove(sandbox);
+                } else if (state.released) {
+                    clearTombstone = true;
+                    states.remove(sandbox);
+                } else {
+                    // Mirrors finished with no deferred release request (drained before teardown,
+                    // or user-managed path). Drop the retain registration only.
+                    states.remove(sandbox);
+                }
+            }
+        }
+        if (toFlush != null) {
+            for (DeferredRelease deferred : toFlush) {
+                scheduleDeferredRelease(deferred.manager, deferred.result);
+            }
+        } else if (clearTombstone) {
+            log.debug(
+                    "[sandbox-mirror-release] cleared released tombstone after late retain"
+                            + " pairing");
+        }
+    }
+
+    private void doRequestRelease(SandboxManager manager, SandboxAcquireResult result) {
+        if (!result.isSelfManaged()) {
+            performRelease(manager, result);
+            return;
+        }
+
+        Sandbox sandbox = result.getSandbox();
+        boolean releaseNow;
+        synchronized (lock) {
+            State state = states.get(sandbox);
+            if (state != null && state.pendingMirrors > 0) {
+                if (state.released) {
+                    // Already destructively released (e.g. prior releaseNow); still close this
+                    // call's lease so it cannot leak, but do not queue another stop/shutdown.
+                    log.warn(
+                            "[sandbox-mirror-release] release requested after sandbox already"
+                                    + " released; closing lease only");
+                    try {
+                        result.getLease().close();
+                    } catch (Exception e) {
+                        log.warn(
+                                "[sandbox-mirror-release] Extra lease close failed: {}",
+                                e.getMessage(),
+                                e);
+                    }
+                    return;
+                }
+                state.deferred.add(new DeferredRelease(manager, result));
+                releaseNow = false;
+            } else {
+                // No outstanding mirrors: sync teardown, then leave a released tombstone so a
+                // late retain cannot re-open an "unreleased" registration.
+                if (state == null) {
+                    state = new State();
+                    states.put(sandbox, state);
+                }
+                state.deferred.clear();
+                state.released = true;
+                releaseNow = true;
+                if (state.pendingMirrors == 0) {
+                    // Keep tombstone only long enough for a racing late retain; if nothing is
+                    // pending, drop it after performRelease via the same map entry until retain.
+                    // pending==0 and released=true is the tombstone.
+                }
+            }
+        }
+        if (releaseNow) {
+            // No outstanding mirrors: keep historical sync teardown on the call thread.
+            performRelease(manager, result);
+            synchronized (lock) {
+                State state = states.get(sandbox);
+                if (state != null && state.pendingMirrors == 0 && state.released) {
+                    // No late retain raced in: drop the tombstone.
+                    states.remove(sandbox);
+                }
+            }
+        }
+    }
+
+    private static List<DeferredRelease> takeDeferred(State state) {
+        List<DeferredRelease> copy = new ArrayList<>(state.deferred);
+        state.deferred.clear();
+        return copy;
+    }
+
+    private static void scheduleDeferredRelease(
+            SandboxManager manager, SandboxAcquireResult result) {
+        try {
+            RELEASE_EXECUTOR.execute(() -> performRelease(manager, result));
+        } catch (RuntimeException e) {
+            log.warn(
+                    "[sandbox-mirror-release] Failed to schedule deferred release; running"
+                            + " inline: {}",
+                    e.getMessage(),
+                    e);
+            performRelease(manager, result);
+        }
+    }
+
+    private static void performRelease(SandboxManager manager, SandboxAcquireResult result) {
+        try {
+            manager.release(result);
+        } catch (Exception e) {
+            log.warn("[sandbox-mirror-release] Sandbox release failed: {}", e.getMessage(), e);
+        } finally {
+            try {
+                result.getLease().close();
+            } catch (Exception e) {
+                log.warn(
+                        "[sandbox-mirror-release] Sandbox lease close failed: {}",
+                        e.getMessage(),
+                        e);
+            }
+        }
+    }
+
+    private static final class DeferredRelease {
+        private final SandboxManager manager;
+        private final SandboxAcquireResult result;
+
+        private DeferredRelease(SandboxManager manager, SandboxAcquireResult result) {
+            this.manager = manager;
+            this.result = result;
+        }
+    }
+
+    private static final class State {
+        private int pendingMirrors;
+        private boolean released;
+        private final List<DeferredRelease> deferred = new ArrayList<>();
+    }
+}

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystemTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/filesystem/sandbox/SandboxBackedFilesystemTest.java
@@ -18,6 +18,7 @@ package io.agentscope.harness.agent.filesystem.sandbox;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.agentscope.core.agent.RuntimeContext;
@@ -25,6 +26,7 @@ import io.agentscope.harness.agent.filesystem.model.FileDownloadResponse;
 import io.agentscope.harness.agent.filesystem.model.FileUploadResponse;
 import io.agentscope.harness.agent.sandbox.ExecResult;
 import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxException;
 import io.agentscope.harness.agent.sandbox.SandboxFileTransfer;
 import io.agentscope.harness.agent.sandbox.SandboxState;
 import io.agentscope.harness.agent.sandbox.WorkspaceSpec;
@@ -337,6 +339,71 @@ class SandboxBackedFilesystemTest {
         assertEquals("transfer down", responses.get(0).error());
     }
 
+    @Test
+    void uploadFiles_whenSandboxStopped_syncPathThrows() {
+        SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
+        FakeTransferSandbox sandbox = new FakeTransferSandbox("/workspace");
+        sandbox.running = false;
+        filesystem.setSandbox(sandbox);
+
+        SandboxException.SandboxConfigurationException thrown =
+                assertThrows(
+                        SandboxException.SandboxConfigurationException.class,
+                        () ->
+                                filesystem.uploadFiles(
+                                        RT,
+                                        List.of(Map.entry("/workspace/a.txt", new byte[] {1}))));
+        assertEquals(SandboxBackedFilesystem.NO_ACTIVE_SANDBOX_MESSAGE, thrown.getMessage());
+        assertTrue(sandbox.uploaded.isEmpty());
+    }
+
+    @Test
+    void uploadFiles_whenSandboxStopped_pinnedMirrorFailsSoft() {
+        FakeTransferSandbox sandbox = new FakeTransferSandbox("/workspace");
+        sandbox.running = false;
+        PinnedSandboxFilesystem filesystem = new PinnedSandboxFilesystem(sandbox);
+
+        List<FileUploadResponse> responses =
+                filesystem.uploadFiles(RT, List.of(Map.entry("/workspace/a.txt", new byte[] {1})));
+
+        assertEquals(1, responses.size());
+        assertTrue(!responses.get(0).isSuccess());
+        assertEquals(SandboxBackedFilesystem.NO_ACTIVE_SANDBOX_MESSAGE, responses.get(0).error());
+        assertTrue(sandbox.uploaded.isEmpty());
+    }
+
+    @Test
+    void downloadFiles_whenSandboxStopped_syncPathThrows() {
+        SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
+        FakeTransferSandbox sandbox = new FakeTransferSandbox("/workspace");
+        sandbox.uploaded.put("/workspace/b.bin", new byte[] {9});
+        sandbox.running = false;
+        filesystem.setSandbox(sandbox);
+
+        SandboxException.SandboxConfigurationException thrown =
+                assertThrows(
+                        SandboxException.SandboxConfigurationException.class,
+                        () -> filesystem.downloadFiles(RT, List.of("/workspace/b.bin")));
+        assertEquals(SandboxBackedFilesystem.NO_ACTIVE_SANDBOX_MESSAGE, thrown.getMessage());
+        assertNull(sandbox.lastCommand);
+    }
+
+    @Test
+    void downloadFiles_whenSandboxStopped_pinnedMirrorFailsSoft() {
+        FakeTransferSandbox sandbox = new FakeTransferSandbox("/workspace");
+        sandbox.uploaded.put("/workspace/b.bin", new byte[] {9});
+        sandbox.running = false;
+        PinnedSandboxFilesystem filesystem = new PinnedSandboxFilesystem(sandbox);
+
+        List<FileDownloadResponse> responses =
+                filesystem.downloadFiles(RT, List.of("/workspace/b.bin"));
+
+        assertEquals(1, responses.size());
+        assertTrue(!responses.get(0).isSuccess());
+        assertEquals(SandboxBackedFilesystem.NO_ACTIVE_SANDBOX_MESSAGE, responses.get(0).error());
+        assertNull(sandbox.lastCommand);
+    }
+
     private static void assertArchive(byte[] archive, String expectedPath, byte[] expectedContent)
             throws IOException {
         try (TarArchiveInputStream tar =
@@ -398,6 +465,7 @@ class SandboxBackedFilesystemTest {
         protected byte[] hydratedArchive;
         protected int hydrateCalls;
         protected boolean failHydration;
+        protected boolean running = true;
 
         protected BaseFakeSandbox(ExecResult execResult) {
             this.execResult = execResult;
@@ -409,7 +477,9 @@ class SandboxBackedFilesystemTest {
         public void start() {}
 
         @Override
-        public void stop() {}
+        public void stop() {
+            running = false;
+        }
 
         @Override
         public void shutdown() {}
@@ -419,7 +489,7 @@ class SandboxBackedFilesystemTest {
 
         @Override
         public boolean isRunning() {
-            return true;
+            return running;
         }
 
         @Override

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/session/SessionTreeMirrorTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/session/SessionTreeMirrorTest.java
@@ -17,25 +17,54 @@ package io.agentscope.harness.agent.memory.session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import io.agentscope.core.agent.RuntimeContext;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.BakedContextFilesystem;
 import io.agentscope.harness.agent.filesystem.remote.store.InMemoryStore;
+import io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem;
 import io.agentscope.harness.agent.filesystem.spec.RemoteFilesystemSpec;
+import io.agentscope.harness.agent.sandbox.ExecResult;
+import io.agentscope.harness.agent.sandbox.Sandbox;
+import io.agentscope.harness.agent.sandbox.SandboxAcquireResult;
+import io.agentscope.harness.agent.sandbox.SandboxFileTransfer;
+import io.agentscope.harness.agent.sandbox.SandboxManager;
+import io.agentscope.harness.agent.sandbox.SandboxMirrorReleaseCoordinator;
+import io.agentscope.harness.agent.sandbox.SandboxState;
 import io.agentscope.harness.agent.transcript.ObjectStoreTranscriptStore;
 import io.agentscope.harness.agent.transcript.TranscriptRef;
 import io.agentscope.harness.agent.transcript.TranscriptStore;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class SessionTreeMirrorTest {
 
     @TempDir Path workspace;
+
+    @BeforeEach
+    void setUpCoordinator() {
+        SandboxMirrorReleaseCoordinator.resetForTests();
+    }
+
+    @AfterEach
+    void tearDownCoordinator() {
+        SandboxMirrorReleaseCoordinator.resetForTests();
+    }
 
     private AbstractFilesystem buildFs(InMemoryStore store) {
         AbstractFilesystem raw =
@@ -237,11 +266,306 @@ class SessionTreeMirrorTest {
                 "canonical .jsonl must be mirrored even when TranscriptStore is bound");
     }
 
+    @Test
+    void flush_defersSelfManagedReleaseUntilMirrorCompletes() throws Exception {
+        CountDownLatch uploadStarted = new CountDownLatch(1);
+        CountDownLatch allowUpload = new CountDownLatch(1);
+        AtomicInteger shutdownCalls = new AtomicInteger();
+        BlockingTransferSandbox sandbox =
+                new BlockingTransferSandbox(uploadStarted, allowUpload, shutdownCalls);
+
+        SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
+        filesystem.setSandbox(sandbox);
+        Path context = workspace.resolve("agents/agent-a/sessions/deferred.jsonl");
+
+        SandboxManager manager = mock(SandboxManager.class);
+        doAnswer(
+                        invocation -> {
+                            SandboxAcquireResult result = invocation.getArgument(0);
+                            result.getSandbox().stop();
+                            result.getSandbox().shutdown();
+                            return null;
+                        })
+                .when(manager)
+                .release(any());
+
+        SessionTree tree = new SessionTree(context, workspace, filesystem);
+        RuntimeContext callRc = RuntimeContext.builder().userId("user-1").build();
+        callRc.put(SandboxAcquireResult.class, SandboxAcquireResult.selfManaged(sandbox));
+        tree.setRuntimeContext(callRc);
+        tree.append(new SessionEntry.MessageEntry(null, null, null, "USER", "hello", null));
+        tree.flush();
+
+        assertTrue(uploadStarted.await(5, TimeUnit.SECONDS), "mirror should start upload");
+
+        SandboxAcquireResult acquireResult = SandboxAcquireResult.selfManaged(sandbox);
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, acquireResult);
+
+        assertEquals(
+                0,
+                shutdownCalls.get(),
+                "self-managed shutdown must wait for outstanding session mirror");
+        verify(manager, times(0)).release(any());
+
+        allowUpload.countDown();
+        assertTrue(SessionTree.awaitMirrorQuiescence(5, TimeUnit.SECONDS));
+
+        assertEquals(1, shutdownCalls.get(), "shutdown runs after mirror finishes");
+        verify(manager, times(1)).release(acquireResult);
+    }
+
+    @Test
+    void flush_defersReleaseUntilBothSegmentAndCanonicalMirrorsComplete() throws Exception {
+        // flush() schedules two pinned tasks when TranscriptStore is bound: segment + canonical.
+        // Release must wait until both releaseMirror calls run.
+        Semaphore uploadPermits = new Semaphore(0);
+        AtomicInteger uploadsStarted = new AtomicInteger();
+        AtomicInteger shutdownCalls = new AtomicInteger();
+        BlockingTransferSandbox sandbox =
+                new BlockingTransferSandbox(uploadPermits, uploadsStarted, shutdownCalls);
+
+        SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
+        filesystem.setSandbox(sandbox);
+        Path context = workspace.resolve("agents/agent-a/sessions/dual-task.jsonl");
+
+        SandboxManager manager = mock(SandboxManager.class);
+        doAnswer(
+                        invocation -> {
+                            SandboxAcquireResult result = invocation.getArgument(0);
+                            result.getSandbox().stop();
+                            result.getSandbox().shutdown();
+                            return null;
+                        })
+                .when(manager)
+                .release(any());
+
+        SessionTree tree = new SessionTree(context, workspace, filesystem);
+        tree.setTranscriptStore(
+                new ObjectStoreTranscriptStore(filesystem),
+                new TranscriptRef("tenant", "agent-a", "dual-task"));
+        tree.append(new SessionEntry.MessageEntry(null, null, null, "USER", "hello", null));
+        tree.flush();
+
+        SandboxAcquireResult acquireResult = SandboxAcquireResult.selfManaged(sandbox);
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, acquireResult);
+
+        assertEquals(0, shutdownCalls.get(), "two retains must keep shutdown deferred");
+
+        // Let the first mirror task finish one transfer; with a single-thread executor the
+        // segment task typically runs first and needs one upload, then releaseMirror drops to 1.
+        assertTrue(
+                waitUntil(() -> uploadsStarted.get() >= 1, 5, TimeUnit.SECONDS),
+                "at least one mirror upload should start");
+        uploadPermits.release(1);
+        assertTrue(
+                waitUntil(() -> uploadsStarted.get() >= 2, 5, TimeUnit.SECONDS),
+                "second mirror task should start while release is still deferred");
+        assertEquals(
+                0,
+                shutdownCalls.get(),
+                "shutdown must still wait for the second outstanding mirror task");
+
+        uploadPermits.release(8);
+        assertTrue(SessionTree.awaitMirrorQuiescence(5, TimeUnit.SECONDS));
+        assertEquals(1, shutdownCalls.get(), "shutdown after both mirror tasks finish");
+        verify(manager, times(1)).release(acquireResult);
+    }
+
+    @Test
+    void flush_retainsPerCallSandboxFromFsRc_notSharedProxyField() throws Exception {
+        // Concurrent distinct sessions share one SandboxBackedFilesystem proxy field (last-writer
+        // wins). Pin/retain must follow SandboxAcquireResult on fsRc (#2490), not that field —
+        // otherwise retain lands on the sibling sandbox and this call's release is immediate.
+        CountDownLatch uploadStarted = new CountDownLatch(1);
+        CountDownLatch allowUpload = new CountDownLatch(1);
+        AtomicInteger shutdownA = new AtomicInteger();
+        AtomicInteger shutdownB = new AtomicInteger();
+        BlockingTransferSandbox sandboxA =
+                new BlockingTransferSandbox(uploadStarted, allowUpload, shutdownA);
+        BlockingTransferSandbox sandboxB =
+                new BlockingTransferSandbox(
+                        new CountDownLatch(1), new CountDownLatch(0), shutdownB);
+
+        SandboxBackedFilesystem filesystem = new SandboxBackedFilesystem();
+        // Sibling call "won" the shared fallback slot.
+        filesystem.setSandbox(sandboxB);
+        Path context = workspace.resolve("agents/agent-a/sessions/per-call-pin.jsonl");
+
+        SandboxManager manager = mock(SandboxManager.class);
+        doAnswer(
+                        invocation -> {
+                            SandboxAcquireResult result = invocation.getArgument(0);
+                            result.getSandbox().stop();
+                            result.getSandbox().shutdown();
+                            return null;
+                        })
+                .when(manager)
+                .release(any());
+
+        SessionTree tree = new SessionTree(context, workspace, filesystem);
+        RuntimeContext callRc =
+                RuntimeContext.builder().userId("user-a").sessionId("sess-a").build();
+        callRc.put(SandboxAcquireResult.class, SandboxAcquireResult.selfManaged(sandboxA));
+        tree.setRuntimeContext(callRc);
+        tree.append(new SessionEntry.MessageEntry(null, null, null, "USER", "hello", null));
+        tree.flush();
+
+        assertTrue(
+                uploadStarted.await(5, TimeUnit.SECONDS),
+                "mirror must upload via per-call sandbox A, not shared-field sandbox B");
+
+        SandboxAcquireResult resultA = SandboxAcquireResult.selfManaged(sandboxA);
+        SandboxAcquireResult resultB = SandboxAcquireResult.selfManaged(sandboxB);
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, resultA);
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, resultB);
+
+        assertEquals(0, shutdownA.get(), "call A still has an outstanding mirror retain");
+        assertEquals(
+                1,
+                shutdownB.get(),
+                "call B has no retain from A's flush — release must not be deferred on B");
+        verify(manager, times(1)).release(resultB);
+        verify(manager, times(0)).release(resultA);
+
+        allowUpload.countDown();
+        assertTrue(SessionTree.awaitMirrorQuiescence(5, TimeUnit.SECONDS));
+        assertEquals(1, shutdownA.get(), "call A shuts down after its mirror finishes");
+        verify(manager, times(1)).release(resultA);
+    }
+
     // -----------------------------------------------------------------------
     //  Helper
     // -----------------------------------------------------------------------
 
     private static void awaitMirror() throws InterruptedException {
         TimeUnit.MILLISECONDS.sleep(300);
+    }
+
+    private static boolean waitUntil(
+            java.util.function.BooleanSupplier condition, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + unit.toNanos(timeout);
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return true;
+            }
+            TimeUnit.MILLISECONDS.sleep(20);
+        }
+        return condition.getAsBoolean();
+    }
+
+    private static final class BlockingTransferSandbox implements Sandbox, SandboxFileTransfer {
+
+        private final CountDownLatch legacyUploadStarted;
+        private final CountDownLatch legacyAllowUpload;
+        private final Semaphore uploadPermits;
+        private final AtomicInteger uploadsStarted;
+        private final AtomicInteger shutdownCalls;
+        private volatile boolean running = true;
+
+        private BlockingTransferSandbox(
+                CountDownLatch uploadStarted,
+                CountDownLatch allowUpload,
+                AtomicInteger shutdownCalls) {
+            this.legacyUploadStarted = uploadStarted;
+            this.legacyAllowUpload = allowUpload;
+            this.uploadPermits = null;
+            this.uploadsStarted = null;
+            this.shutdownCalls = shutdownCalls;
+        }
+
+        private BlockingTransferSandbox(
+                Semaphore uploadPermits,
+                AtomicInteger uploadsStarted,
+                AtomicInteger shutdownCalls) {
+            this.legacyUploadStarted = null;
+            this.legacyAllowUpload = null;
+            this.uploadPermits = uploadPermits;
+            this.uploadsStarted = uploadsStarted;
+            this.shutdownCalls = shutdownCalls;
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public void stop() {
+            running = false;
+        }
+
+        @Override
+        public void shutdown() {
+            shutdownCalls.incrementAndGet();
+            running = false;
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public boolean isRunning() {
+            return running;
+        }
+
+        @Override
+        public SandboxState getState() {
+            return null;
+        }
+
+        @Override
+        public ExecResult exec(
+                RuntimeContext runtimeContext, String command, Integer timeoutSeconds) {
+            throw new AssertionError("not used");
+        }
+
+        @Override
+        public InputStream persistWorkspace() {
+            throw new AssertionError("not used");
+        }
+
+        @Override
+        public void hydrateWorkspace(InputStream archive) {
+            // Archive fallback when workspace root is unavailable — still holds the mirror gate.
+            blockUntilAllowed();
+        }
+
+        @Override
+        public boolean supportsFileTransfer(String absolutePath) {
+            return true;
+        }
+
+        @Override
+        public void uploadFile(String absolutePath, byte[] content) {
+            blockUntilAllowed();
+        }
+
+        @Override
+        public byte[] downloadFile(String absolutePath) {
+            throw new AssertionError("not used");
+        }
+
+        private void blockUntilAllowed() {
+            if (uploadPermits != null) {
+                uploadsStarted.incrementAndGet();
+                try {
+                    if (!uploadPermits.tryAcquire(5, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("timed out waiting for upload permit");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(e);
+                }
+                return;
+            }
+            legacyUploadStarted.countDown();
+            try {
+                if (!legacyAllowUpload.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("timed out waiting to finish upload");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            }
+        }
     }
 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SandboxMirrorReleaseCoordinatorTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/sandbox/SandboxMirrorReleaseCoordinatorTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.sandbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SandboxMirrorReleaseCoordinatorTest {
+
+    private SandboxManager manager;
+    private Sandbox sandbox;
+    private AtomicInteger releaseCalls;
+    private AtomicBoolean leaseClosed;
+
+    @BeforeEach
+    void setUp() {
+        SandboxMirrorReleaseCoordinator.resetForTests();
+        releaseCalls = new AtomicInteger();
+        leaseClosed = new AtomicBoolean(false);
+        sandbox = mock(Sandbox.class);
+        manager = mock(SandboxManager.class);
+        org.mockito.Mockito.doAnswer(
+                        invocation -> {
+                            releaseCalls.incrementAndGet();
+                            return null;
+                        })
+                .when(manager)
+                .release(org.mockito.ArgumentMatchers.any());
+    }
+
+    @AfterEach
+    void tearDown() {
+        SandboxMirrorReleaseCoordinator.resetForTests();
+    }
+
+    @Test
+    void requestRelease_withoutPendingMirrors_releasesImmediately() {
+        SandboxAcquireResult result = selfManagedWithLease(sandbox);
+
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, result);
+
+        assertEquals(1, releaseCalls.get());
+        assertTrue(leaseClosed.get());
+        verify(manager, times(1)).release(result);
+    }
+
+    @Test
+    void requestRelease_withPendingMirror_defersUntilReleaseMirror() {
+        SandboxAcquireResult result = selfManagedWithLease(sandbox);
+
+        SandboxMirrorReleaseCoordinator.retain(sandbox);
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, result);
+
+        assertEquals(0, releaseCalls.get());
+        assertFalse(leaseClosed.get());
+        verify(manager, never()).release(result);
+
+        SandboxMirrorReleaseCoordinator.releaseMirror(sandbox);
+        assertTrue(awaitDeferredRelease());
+
+        assertEquals(1, releaseCalls.get());
+        assertTrue(leaseClosed.get());
+        verify(manager, times(1)).release(result);
+    }
+
+    @Test
+    void twoRetains_requireTwoReleaseMirrors_beforeDeferredRelease() {
+        SandboxAcquireResult result = selfManagedWithLease(sandbox);
+
+        SandboxMirrorReleaseCoordinator.retain(sandbox);
+        SandboxMirrorReleaseCoordinator.retain(sandbox);
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, result);
+
+        SandboxMirrorReleaseCoordinator.releaseMirror(sandbox);
+        assertTrue(awaitDeferredRelease());
+        assertEquals(0, releaseCalls.get());
+        assertFalse(leaseClosed.get());
+
+        SandboxMirrorReleaseCoordinator.releaseMirror(sandbox);
+        assertTrue(awaitDeferredRelease());
+        assertEquals(1, releaseCalls.get());
+        assertTrue(leaseClosed.get());
+    }
+
+    @Test
+    void mirrorFinishesBeforeRequestRelease_thenRequestReleasesImmediately() {
+        SandboxAcquireResult result = selfManagedWithLease(sandbox);
+
+        SandboxMirrorReleaseCoordinator.retain(sandbox);
+        SandboxMirrorReleaseCoordinator.releaseMirror(sandbox);
+
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, result);
+
+        assertEquals(1, releaseCalls.get());
+        assertTrue(leaseClosed.get());
+    }
+
+    @Test
+    void userManaged_releasesImmediatelyEvenWithPendingMirrors() {
+        SandboxAcquireResult result = SandboxAcquireResult.userManaged(sandbox);
+        SandboxMirrorReleaseCoordinator.retain(sandbox);
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, result);
+
+        assertEquals(1, releaseCalls.get());
+        verify(manager, times(1)).release(result);
+
+        // drain retain so state does not leak across tests
+        SandboxMirrorReleaseCoordinator.releaseMirror(sandbox);
+    }
+
+    @Test
+    void releaseMirror_afterFailurePath_stillReleasesDeferred() {
+        SandboxAcquireResult result = selfManagedWithLease(sandbox);
+
+        SandboxMirrorReleaseCoordinator.retain(sandbox);
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, result);
+
+        SandboxMirrorReleaseCoordinator.releaseMirror(sandbox);
+        assertTrue(awaitDeferredRelease());
+
+        assertEquals(1, releaseCalls.get());
+        assertTrue(leaseClosed.get());
+    }
+
+    @Test
+    void releaseMirror_underflow_takesOverDeferredRelease() {
+        SandboxAcquireResult result = selfManagedWithLease(sandbox);
+
+        SandboxMirrorReleaseCoordinator.retain(sandbox);
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, result);
+        SandboxMirrorReleaseCoordinator.forcePendingZeroForUnderflowTests(sandbox);
+
+        SandboxMirrorReleaseCoordinator.releaseMirror(sandbox);
+        assertTrue(awaitDeferredRelease());
+
+        assertEquals(
+                1,
+                releaseCalls.get(),
+                "underflow with deferred must take over stop/shutdown so the lease is not"
+                        + " orphaned");
+        assertTrue(leaseClosed.get());
+        verify(manager, times(1)).release(result);
+    }
+
+    @Test
+    void releaseMirror_underflow_withoutDeferred_doesNotRelease() {
+        SandboxMirrorReleaseCoordinator.retain(sandbox);
+        SandboxMirrorReleaseCoordinator.forcePendingZeroForUnderflowTests(sandbox);
+
+        SandboxMirrorReleaseCoordinator.releaseMirror(sandbox);
+
+        assertEquals(0, releaseCalls.get());
+        assertFalse(leaseClosed.get());
+        verify(manager, never()).release(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void deferredRelease_doesNotRunOnCallerThread() {
+        SandboxAcquireResult result = selfManagedWithLease(sandbox);
+        Thread caller = Thread.currentThread();
+        AtomicBoolean ranOnCaller = new AtomicBoolean(false);
+
+        org.mockito.Mockito.doAnswer(
+                        invocation -> {
+                            ranOnCaller.set(Thread.currentThread() == caller);
+                            releaseCalls.incrementAndGet();
+                            return null;
+                        })
+                .when(manager)
+                .release(org.mockito.ArgumentMatchers.any());
+
+        SandboxMirrorReleaseCoordinator.retain(sandbox);
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, result);
+        SandboxMirrorReleaseCoordinator.releaseMirror(sandbox);
+        assertTrue(awaitDeferredRelease());
+
+        assertEquals(1, releaseCalls.get());
+        assertFalse(ranOnCaller.get(), "deferred stop/shutdown must not run on the mirror caller");
+    }
+
+    @Test
+    void twoCallsSharingSandbox_bothDeferredReleasesRun() {
+        AtomicInteger leaseCloses = new AtomicInteger();
+        SandboxAcquireResult resultA =
+                SandboxAcquireResult.selfManaged(sandbox, leaseCloses::incrementAndGet);
+        SandboxAcquireResult resultB =
+                SandboxAcquireResult.selfManaged(sandbox, leaseCloses::incrementAndGet);
+
+        SandboxMirrorReleaseCoordinator.retain(sandbox);
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, resultA);
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, resultB);
+
+        assertEquals(0, releaseCalls.get());
+        assertEquals(0, leaseCloses.get());
+
+        SandboxMirrorReleaseCoordinator.releaseMirror(sandbox);
+        assertTrue(awaitDeferredRelease());
+
+        assertEquals(2, releaseCalls.get(), "each call's manager.release must run");
+        assertEquals(2, leaseCloses.get(), "each call's lease must close");
+        verify(manager, times(1)).release(resultA);
+        verify(manager, times(1)).release(resultB);
+    }
+
+    @Test
+    void lateRetainAfterReleaseNow_pairsWithoutSecondRelease() {
+        SandboxAcquireResult result = selfManagedWithLease(sandbox);
+
+        SandboxMirrorReleaseCoordinator.requestRelease(manager, result);
+        assertEquals(1, releaseCalls.get());
+        assertTrue(leaseClosed.get());
+
+        // Race: retain lands while the released tombstone is still visible (or after). Either way
+        // pairing must not schedule another destructive release.
+        SandboxMirrorReleaseCoordinator.retain(sandbox);
+        SandboxMirrorReleaseCoordinator.releaseMirror(sandbox);
+        assertTrue(awaitDeferredRelease());
+
+        assertEquals(1, releaseCalls.get(), "must not release twice after late retain pairing");
+    }
+
+    private static boolean awaitDeferredRelease() {
+        return SandboxMirrorReleaseCoordinator.awaitReleaseQuiescence(5, TimeUnit.SECONDS);
+    }
+
+    private SandboxAcquireResult selfManagedWithLease(Sandbox sb) {
+        SandboxLease lease =
+                () -> {
+                    leaseClosed.set(true);
+                };
+        return SandboxAcquireResult.selfManaged(sb, lease);
+    }
+}


### PR DESCRIPTION
## Summary
Fix NPE caused by synchronous call shutdown clearing sandbox connections before async sandbox write completes
Fixes #3036

## Behavior notes (ops)
Repair Ideas：
When a call completes, if there are still outstanding asynchronous mirror tasks relying on the sandbox connection, do not destroy the connection immediately. Defer the release ownership until the reference count drops to zero.

Key changes:
1. Add a new deferred‑release coordinator
‑ Enqueue mirror task: call `retain()` (increment reference count by 1)
‑ Task completion: call `releaseMirror()` (decrement count by 1; perform real shutdown only when count reaches zero)
‑ Call teardown: call `requestRelease()` — if pending tasks exist, defer destruction; otherwise shut down immediately
‑ Self‑managed sandbox: keep existing behavior; do not physically destroy the sandbox instance
2. In `SessionTree`, prepare data before enqueuing asynchronous mirror tasks and then invoke `retain()`. Roll back the reference count upon submission failure. Decrement the count inside the `finally` block.
3. Destruction must not block mirror threads. Deferred `stop()/shutdown()` runs on a dedicated cleanup thread, preventing slow‑teardown operations from blocking the global mirror queue.
4. Defensive safeguards
‑ When the sandbox is already stopped (`isRunning() == false`), treat upload/download as soft‑fail to avoid crashing on dead connections.
‑ Prevent unintended destruction when reference‑count underflow occurs (count goes negative).
5. Test coverage
‑ Deferred‑release logic
‑ Sandbox shutdown only after completion of dual tasks (segment‑level + full‑file mirroring)
‑ Avoid premature teardown on reference‑count underflow

## Test plan

- [x] `mvn -pl agentscope-harness -am -DskipITs -Dtest=SandboxMirrorReleaseCoordinatorTest,SessionTreeMirrorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] `mvn -pl agentscope-harness -am -DskipITs -Dtest=SandboxBackedFilesystemTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] Manual: self-managed K8s/Docker call with session flush — mirror completes, then pod/claim terminates; no NPE on `session-tree-mirror`
- [x] Manual: user-managed sandbox path still reuses sandbox across calls (no shutdown on release)