### PR TITLE
fix(example): fix/data-agent-multi-session-inbox-routing

### DIFF
--- a/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/api/ChatController.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/main/java/io/agentscope/dataagent/web/api/ChatController.java
@@ -34,6 +34,7 @@ import io.agentscope.dataagent.web.share.AgentAccessGuard;
 import io.agentscope.dataagent.web.share.AgentAclService.Tier;
 import io.agentscope.dataagent.web.toolbus.ToolEventBus;
 import io.agentscope.dataagent.web.usage.UsageStore;
+import io.agentscope.harness.agent.HarnessAgent;
 import io.agentscope.harness.agent.gateway.MsgContext;
 import io.agentscope.harness.agent.gateway.channel.InboundMessage;
 import io.agentscope.harness.agent.gateway.channel.Peer;
@@ -364,17 +365,42 @@ public class ChatController {
      */
     private String resolveGateKey(String userId, String agentId, String conversationId) {
         if (agentId == null || agentId.isBlank()) return null;
+        if (conversationId == null || conversationId.isBlank()) return null;
         try {
             String gatewayAgentId = catalogService.resolveGatewayAgentId(userId, agentId);
             InboundMessage probe =
-                    InboundMessage.builder(ChatUiChannel.CHANNEL_ID, Peer.direct(userId), List.of())
-                            .preferredAgentId(gatewayAgentId)
-                            .accountId(conversationId)
-                            .build();
+                    buildConversationInbound(userId, gatewayAgentId, conversationId, List.of());
             return chatUiChannel.previewRoute(probe).context().canonicalKey();
         } catch (Exception e) {
             return null;
         }
+    }
+
+    /**
+     * Builds an inbound message whose routing key carries {@code conversationId} in the {@code |t:}
+     * segment via a thread peer. {@code senderId} must be set because thread peers are not DM peers
+     * and the router would otherwise lose the authenticated user id.
+     *
+     * <p>{@code conversationId} must be non-blank — HTTP stream/send mint a UUID before dispatch;
+     * callers must not fall back to a DM-shaped key.
+     */
+    static InboundMessage buildConversationInbound(
+            String userId, String gatewayAgentId, String conversationId, List<Msg> messages) {
+        Objects.requireNonNull(userId, "userId");
+        if (conversationId == null || conversationId.isBlank()) {
+            throw new IllegalArgumentException(
+                    "conversationId is required; stream/send must mint a UUID before dispatch");
+        }
+        List<Msg> payload = messages != null ? List.copyOf(messages) : List.of();
+        InboundMessage.Builder builder =
+                InboundMessage.builder(
+                                ChatUiChannel.CHANNEL_ID, Peer.thread(conversationId), payload)
+                        .senderId(userId)
+                        .parentPeer(Peer.direct(userId));
+        if (gatewayAgentId != null && !gatewayAgentId.isBlank()) {
+            builder.preferredAgentId(gatewayAgentId);
+        }
+        return builder.build();
     }
 
     /**
@@ -537,28 +563,44 @@ public class ChatController {
      *
      * <p>When {@code agentId} is blank (defensive — controller always supplies one), falls back to
      * pure binding-driven routing: the chatui channel's default agent or matching binding wins.
+     *
+     * <p>{@code conversationId} must already be pinned (stream/send mint a UUID when the client
+     * omits {@code sessionKey}). A blank id is rejected so probe ({@link #resolveGateKey}) and
+     * dispatch never diverge on session identity.
      */
     private Mono<Msg> executeChat(
             String userId, String agentId, String message, String conversationId) {
         long startMs = System.currentTimeMillis();
+
+        if (agentId != null && !agentId.isBlank()) {
+            HarnessAgent ha = catalogService.getRunningAgent(userId, agentId);
+            if (ha != null && ha.getModel() == null) {
+                return Mono.error(
+                        new IllegalStateException(
+                                "No LLM model configured for agent '"
+                                        + agentId
+                                        + "'. Provide a Model Spring bean or configure model"
+                                        + " options under dataagent.* in application.yml."));
+            }
+        }
+
+        String pinnedConversationId = normalizedConversationId(conversationId);
+        if (pinnedConversationId == null) {
+            return Mono.error(
+                    new IllegalArgumentException(
+                            "conversationId is required; stream/send must mint a UUID before"
+                                    + " executeChat"));
+        }
 
         List<Msg> msgs =
                 shapeInboundMessages(userBindings.list(userId), ChatUiChannel.CHANNEL_ID, message);
 
         InboundMessage inbound;
         if (agentId == null || agentId.isBlank()) {
-            // No agent override and no conversation scoping — pure binding-driven routing.
-            inbound = InboundMessage.dm(ChatUiChannel.CHANNEL_ID, userId, List.copyOf(msgs));
+            inbound = buildConversationInbound(userId, null, pinnedConversationId, msgs);
         } else {
             String gatewayAgentId = catalogService.resolveGatewayAgentId(userId, agentId);
-            inbound =
-                    InboundMessage.builder(
-                                    ChatUiChannel.CHANNEL_ID,
-                                    Peer.direct(userId),
-                                    List.copyOf(msgs))
-                            .preferredAgentId(gatewayAgentId)
-                            .accountId(conversationId)
-                            .build();
+            inbound = buildConversationInbound(userId, gatewayAgentId, pinnedConversationId, msgs);
         }
         Mono<Msg> call = chatUiChannel.dispatch(inbound);
 

--- a/agentscope-examples/agents/agentscope-dataagent/src/test/java/io/agentscope/dataagent/web/api/ChatControllerConversationRoutingTest.java
+++ b/agentscope-examples/agents/agentscope-dataagent/src/test/java/io/agentscope/dataagent/web/api/ChatControllerConversationRoutingTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.dataagent.web.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.harness.agent.gateway.channel.ChannelConfig;
+import io.agentscope.harness.agent.gateway.channel.DmScope;
+import io.agentscope.harness.agent.gateway.channel.InboundMessage;
+import io.agentscope.harness.agent.gateway.channel.Peer;
+import io.agentscope.harness.agent.gateway.channel.chatui.ChatUiChannel;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Verifies conversation-scoped inbound routing produces distinct gate keys per conversation. */
+class ChatControllerConversationRoutingTest {
+
+    private static final ChatUiChannel CHANNEL =
+            ChatUiChannel.create(
+                    ChannelConfig.builder("chatui")
+                            .defaultAgentId("data-agent")
+                            .dmScope(DmScope.MAIN)
+                            .build());
+
+    private static String gateKey(InboundMessage inbound) {
+        return CHANNEL.previewRoute(inbound).context().canonicalKey();
+    }
+
+    @Test
+    void differentConversationIdsProduceDistinctGateKeysWithThreadSegment() {
+        InboundMessage a =
+                ChatController.buildConversationInbound(
+                        "user-1", "data-agent", "conv-a", List.of());
+        InboundMessage b =
+                ChatController.buildConversationInbound(
+                        "user-1", "data-agent", "conv-b", List.of());
+
+        String gateKeyA = gateKey(a);
+        String gateKeyB = gateKey(b);
+
+        assertThat(gateKeyA).isNotEqualTo(gateKeyB);
+        assertThat(gateKeyA).contains("|t:conv-a");
+        assertThat(gateKeyB).contains("|t:conv-b");
+        assertThat(SessionController.extractConversationId(gateKeyA)).isEqualTo("conv-a");
+        assertThat(SessionController.extractConversationId(gateKeyB)).isEqualTo("conv-b");
+    }
+
+    @Test
+    void sameConversationIdMapsToSameGateKey() {
+        InboundMessage first =
+                ChatController.buildConversationInbound(
+                        "user-1", "data-agent", "conv-a", List.of());
+        InboundMessage second =
+                ChatController.buildConversationInbound(
+                        "user-1", "data-agent", "conv-a", List.of());
+
+        assertThat(gateKey(first)).isEqualTo(gateKey(second));
+    }
+
+    @Test
+    void probeAndDispatchInboundShareCanonicalKey() {
+        InboundMessage probe =
+                ChatController.buildConversationInbound(
+                        "user-1", "data-agent", "conv-a", List.of());
+        InboundMessage dispatch =
+                ChatController.buildConversationInbound(
+                        "user-1",
+                        "data-agent",
+                        "conv-a",
+                        List.of(Msg.builder().role(MsgRole.USER).textContent("hello").build()));
+
+        assertThat(gateKey(probe)).isEqualTo(gateKey(dispatch));
+    }
+
+    @Test
+    void blankConversationIdIsRejectedByBuildConversationInbound() {
+        assertThatThrownBy(
+                        () ->
+                                ChatController.buildConversationInbound(
+                                        "user-1", "data-agent", null, List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("conversationId");
+        assertThatThrownBy(
+                        () ->
+                                ChatController.buildConversationInbound(
+                                        "user-1", "data-agent", "  ", List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("conversationId");
+    }
+
+    @Test
+    void threadInboundCarriesSenderIdAndParentPeer() {
+        InboundMessage inbound =
+                ChatController.buildConversationInbound(
+                        "user-1", "data-agent", "conv-a", List.of());
+
+        assertThat(inbound.senderId()).isEqualTo("user-1");
+        assertThat(inbound.parentPeer()).isEqualTo(Peer.direct("user-1"));
+        assertThat(inbound.peer()).isEqualTo(Peer.thread("conv-a"));
+    }
+
+    @Test
+    void sameUserDifferentConversationsShareRoomButNotThread() {
+        InboundMessage a =
+                ChatController.buildConversationInbound(
+                        "user-1", "data-agent", "conv-a", List.of());
+        InboundMessage b =
+                ChatController.buildConversationInbound(
+                        "user-1", "data-agent", "conv-b", List.of());
+
+        String gateKeyA = gateKey(a);
+        String gateKeyB = gateKey(b);
+
+        assertThat(gateKeyA).contains("|r:user-1");
+        assertThat(gateKeyB).contains("|r:user-1");
+        assertThat(gateKeyA).isNotEqualTo(gateKeyB);
+    }
+}


### PR DESCRIPTION
## AgentScope-Java Version

2.0.3-SNAPSHOT

## Description

### Background
Fixes [#1626](https://github.com/agentscope-ai/agentscope-java/issues/2735)
After the data-agent is launched locally, creating a second chat session causes the new session to **replace** the previous one in the left history sidebar, so only one session ever appears. Expected behavior: multiple independent sessions for the same user and agent should coexist in the inbox.
New conversations keep overwriting old ones, leaving only a single session visible on the left sidebar：
<img width="1717" height="639" alt="da修复前" src="https://github.com/user-attachments/assets/ba688f3c-ac77-4f11-a5ab-cb9388c9bd2d" />
<img width="1711" height="541" alt="da修复前2" src="https://github.com/user-attachments/assets/5c87c24d-f858-499f-8e6b-fea8d9b35c2a" />

### Root causes

Every new conversation created on the frontend generates a distinct `conversationId`. However, the backend route does not incorporate this value into the session identifier. As a result, all conversations are mapped to the same backend session, which explains why the inbox only returns a single entry.
- Frontend: works correctly, each new conversation gets a unique ID
- Backend: the wrong field is passed for `conversationId`, so the routing layer cannot distinguish individual conversations
- Result: the gateway reuses the same MAIN session → only one entry appears in the history list

### Repair ideas
- Use **Thread peer** to inject `conversationId` into the routing key (`|t:xxx`), so that each new conversation maps to a dedicated backend session.
- As a side improvement: instead of throwing an obscure NPE when no LLM is configured, return a prompt asking for the `DASHSCOPE_API_KEY` configuration.

### Changes
| File | Change |
|------|------|
| `ChatController` | Consistently use `buildConversationInbound()` to construct inbound messages, and perform routing based on conversation‑ID |
| `ChatController` | Fail fast when no model is configured, with a hint to set the API Key |
| `ChatControllerConversationRoutingTest` | Unit test: verify distinct `conversationId` resolves to different `gateKey` |

after fix：
<img width="1721" height="621" alt="da修复后" src="https://github.com/user-attachments/assets/784842a3-3d26-4082-838f-c80370341bd7" />

### How to test

1. Run unit tests:

   ```bash
   mvn -pl agentscope-examples/agents/agentscope-dataagent -am \
     test -Dtest=ChatControllerConversationRoutingTest \
     -Dfrontend-maven-plugin.skip=true
   ```

   Expected: `BUILD SUCCESS`.

2. **Manual verification**
‑ Configure `DASHSCOPE_API_KEY` and start the Data Agent
‑ Send messages in Session A → one entry appears in the sidebar
‑ Click "New Conversation", send messages in Session B → **two entries** show up in the sidebar
‑ Switch back to Session A and refresh the page → both entries remain, conversation history works as expected

## Checklist
- [x] `mvn spotless:apply`（如需要）
- [x] 单测通过（`ChatControllerConversationRoutingTest`，BUILD SUCCESS）
- [x] 设计文档已补充
