### PR TITLE
fix: emit permission-denied tool result events

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -52,10 +52,8 @@ jobs:
             repo-cache-path: '~/.m2/repository'
           - os: windows-latest
             repo-cache-path: '~\.m2\repository'
-            mvnd-cache-path: '~\.mvnd'
 
     env:
-      MVND_VERSION: '1.0.3'
       JAVA_VERSION: '17'
 
     steps:
@@ -75,32 +73,6 @@ jobs:
           restore-keys: |
             maven-${{ runner.os }}-
 
-      - name: Cache mvnd [${{ runner.os }}]
-        if: runner.os == 'Windows'
-        id: cache-mvnd
-        uses: actions/cache@v4
-        with:
-          path: ${{ matrix.mvnd-cache-path }}
-          key: mvnd-${{ env.MVND_VERSION }}-${{ runner.os }}
-
-      - name: Install mvnd [Windows]
-        if: steps.cache-mvnd.outputs.cache-hit != 'true' && runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Invoke-WebRequest `
-            -Uri "https://github.com/apache/maven-mvnd/releases/download/${{ env.MVND_VERSION }}/maven-mvnd-${{ env.MVND_VERSION }}-windows-amd64.zip" `
-            -OutFile "mvnd.zip"
-          mkdir -Path "~\.mvnd" -Force
-          Expand-Archive -Path "mvnd.zip" -DestinationPath "mvnd" -FORCE
-          Copy-Item -Path "mvnd\maven-mvnd-${{ env.MVND_VERSION }}-windows-amd64\*" -Destination "~\.mvnd\" -Recurse
-          Set-Content -Path "~\.mvnd\conf\mvnd.properties" -Value @"
-          # mvnd client timeout settings
-          mvnd.connectTimeout=120000
-          mvnd.socketConnectTimeout=30000
-          mvnd.cancelConnectTimeout=30000
-          "@ -Encoding Utf8 -Force
-          Remove-Item -Path "mvnd", "mvnd.zip" -Recurse -Force
-
       - name: Build and Test with Coverage [Linux]
         if: runner.os == 'Linux'
         shell: bash
@@ -114,8 +86,8 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           # -T1: single-threaded build so reactor order is respected (see Linux step).
-          # -Dmvnd.maxLostKeepAlive=120: avoid StaleAddressException on long javadoc phases (mvnd#161).
-          & "~\.mvnd\bin\mvnd.cmd" -B -T1 "-Dmvnd.maxLostKeepAlive=120" clean verify
+          # Use standard Maven to avoid mvnd daemon startup/communication failures.
+          mvn -B -T1 clean verify
 
       - name: Upload coverage reports to Codecov
         if: runner.os == 'Linux'

--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1908,12 +1908,14 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
             }
 
             String replyId = resolvePendingRequestReplyId(Msg.METADATA_CONFIRM_REQUEST_REPLY_ID);
-            if (!replyId.isEmpty()) {
-                publishEvent(new UserConfirmResultEvent(replyId, normalized));
-                clearPendingRequestReplyId(Msg.METADATA_CONFIRM_REQUEST_REPLY_ID);
+            if (replyId.isEmpty()) {
+                // Older persisted ASKING calls may not carry request correlation metadata.
+                replyId = UUID.randomUUID().toString().replace("-", "");
             }
+            publishEvent(new UserConfirmResultEvent(replyId, normalized));
+            clearPendingRequestReplyId(Msg.METADATA_CONFIRM_REQUEST_REPLY_ID);
 
-            applyConfirmResults(normalized);
+            applyConfirmResults(normalized, replyId);
         }
 
         /** Resolve the reply id for the pending HITL request stored on the last assistant message. */
@@ -1975,10 +1977,10 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          *       modified) one from the result, set state to {@link ToolCallState#ALLOWED}, and
          *       register any attached {@link PermissionRule}s with the engine.</li>
          *   <li>{@code confirmed == false}: write a DENIED {@link ToolResultBlock} to context so
-         *       the tool will no longer be pending on resume.</li>
+         *       the tool will no longer be pending on resume, and publish its result events.</li>
          * </ul>
          */
-        private void applyConfirmResults(List<ConfirmResult> results) {
+        private void applyConfirmResults(List<ConfirmResult> results, String replyId) {
             // Replace ASKING ToolUseBlocks with possibly-modified ones from the user, and
             // promote them to ALLOWED. Collect denied ones for separate handling.
             List<ToolUseBlock> deniedToolCalls = new ArrayList<>();
@@ -2011,6 +2013,8 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         ToolResultMessageBuilder.buildToolResultMsg(
                                 deniedResult, denied, getName());
                 state.contextMutable().add(deniedMsg);
+                deniedToolResultEvents(denied, replyId, "Permission denied by user")
+                        .forEach(this::publishEvent);
             }
         }
 
@@ -2919,11 +2923,21 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                                 resultHolder.set(List.of());
                                 persistPendingRequestReplyId(
                                         Msg.METADATA_CONFIRM_REQUEST_REPLY_ID, replyId);
-                                return Flux.<AgentEvent>just(
-                                        new RequireUserConfirmEvent(replyId, pending),
-                                        new RequestStopEvent(
-                                                "permission asking",
-                                                GenerateReason.PERMISSION_ASKING));
+                                return Flux.fromIterable(toolCalls)
+                                        .filter(tc -> autoDenied.contains(tc.getId()))
+                                        .concatMapIterable(
+                                                tc ->
+                                                        deniedToolResultEvents(
+                                                                tc,
+                                                                replyId,
+                                                                "Permission denied by rules"))
+                                        .concatWith(
+                                                Flux.just(
+                                                        new RequireUserConfirmEvent(
+                                                                replyId, pending),
+                                                        new RequestStopEvent(
+                                                                "permission asking",
+                                                                GenerateReason.PERMISSION_ASKING)));
                             })
                     .doOnNext(this::publishEvent);
         }
@@ -2945,6 +2959,17 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 Msg deniedMsg = ToolResultMessageBuilder.buildToolResultMsg(denied, tc, getName());
                 state.contextMutable().add(deniedMsg);
             }
+        }
+
+        /** Build the same complete result lifecycle for every permission-denial path. */
+        private List<AgentEvent> deniedToolResultEvents(
+                ToolUseBlock toolCall, String replyId, String reason) {
+            return List.of(
+                    new ToolResultStartEvent(replyId, toolCall.getId(), toolCall.getName()),
+                    new ToolResultTextDeltaEvent(
+                            replyId, toolCall.getId(), toolCall.getName(), reason),
+                    new ToolResultEndEvent(
+                            replyId, toolCall.getId(), toolCall.getName(), ToolResultState.DENIED));
         }
 
         /**
@@ -2975,23 +3000,12 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
 
             Flux<AgentEvent> deniedEvents =
                     Flux.fromIterable(deniedEntries)
-                            .concatMap(
-                                    entry -> {
-                                        ToolUseBlock use = entry.getKey();
-                                        return Flux.<AgentEvent>just(
-                                                new ToolResultStartEvent(
-                                                        replyId, use.getId(), use.getName()),
-                                                new ToolResultTextDeltaEvent(
-                                                        replyId,
-                                                        use.getId(),
-                                                        use.getName(),
-                                                        "Permission denied by rules"),
-                                                new ToolResultEndEvent(
-                                                        replyId,
-                                                        use.getId(),
-                                                        use.getName(),
-                                                        ToolResultState.DENIED));
-                                    });
+                            .concatMapIterable(
+                                    entry ->
+                                            deniedToolResultEvents(
+                                                    entry.getKey(),
+                                                    replyId,
+                                                    "Permission denied by rules"));
 
             if (approved.isEmpty()) {
                 resultHolder.set(deniedEntries);

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -23,9 +23,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.event.AgentEvent;
 import io.agentscope.core.event.ConfirmResult;
+import io.agentscope.core.event.ModelCallStartEvent;
 import io.agentscope.core.event.RequestStopEvent;
 import io.agentscope.core.event.RequireUserConfirmEvent;
 import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.event.ToolResultStartEvent;
+import io.agentscope.core.event.ToolResultTextDeltaEvent;
 import io.agentscope.core.event.UserConfirmResultEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.GenerateReason;
@@ -52,6 +55,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -115,7 +120,9 @@ class ReActAgentHitlTest {
         return ChatResponse.builder().content(List.copyOf(toolUses)).build();
     }
 
-    private static final class AskingTool extends ToolBase {
+    private static class AskingTool extends ToolBase {
+        private final AtomicInteger executions = new AtomicInteger();
+
         AskingTool(String name) {
             super(name, "asks for permission", schemaFor(), false, true, false, null, false, false);
         }
@@ -140,6 +147,7 @@ class ReActAgentHitlTest {
         @Override
         public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
             Object q = param.getInput() == null ? "" : param.getInput().get("query");
+            executions.incrementAndGet();
             return Mono.just(ToolResultBlock.text("executed:" + q));
         }
     }
@@ -406,6 +414,186 @@ class ReActAgentHitlTest {
                                         "tc1".equals(tr.getId())
                                                 && tr.getState() == ToolResultState.DENIED);
         assertTrue(foundDenied, "expected a DENIED ToolResultBlock for the rejected tool");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void deniedResumeEmitsCompleteResultEvenWithoutSavedReplyId(boolean legacyState) {
+        AskingTool tool = new AskingTool("ask");
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "ask", "x")),
+                                () -> Flux.just(textResponse("done"))));
+        try (ReActAgent agent = buildAgent(model, toolkitWith(tool))) {
+            List<AgentEvent> paused = agent.streamEvents(List.of()).collectList().block();
+            RequireUserConfirmEvent request =
+                    (RequireUserConfirmEvent)
+                            paused.get(indexOf(paused, RequireUserConfirmEvent.class));
+            if (legacyState) {
+                List<Msg> context = agent.getAgentState().contextMutable();
+                for (int i = 0; i < context.size(); i++) {
+                    Msg msg = context.get(i);
+                    Map<String, Object> metadata = new HashMap<>(msg.getMetadata());
+                    metadata.remove(Msg.METADATA_CONFIRM_REQUEST_REPLY_ID);
+                    context.set(i, msg.withMetadata(metadata));
+                }
+            }
+            List<AgentEvent> resumed =
+                    agent.streamEvents(List.of(confirmMsg(false, request.getToolCalls().get(0))))
+                            .collectList()
+                            .block();
+            assertDeniedEvents(resumed, "tc1", "ask", "Permission denied by user");
+            ToolResultStartEvent start =
+                    (ToolResultStartEvent)
+                            resumed.get(indexOf(resumed, ToolResultStartEvent.class));
+            assertTrue(start.getReplyId() != null && !start.getReplyId().isBlank());
+            int confirmIndex = indexOf(resumed, UserConfirmResultEvent.class);
+            assertTrue(confirmIndex >= 0);
+            assertTrue(confirmIndex < indexOf(resumed, ToolResultStartEvent.class));
+            assertEquals(
+                    start.getReplyId(),
+                    ((UserConfirmResultEvent) resumed.get(confirmIndex)).getReplyId());
+            assertTrue(
+                    indexOf(resumed, ToolResultEndEvent.class)
+                            < indexOf(resumed, ModelCallStartEvent.class));
+            if (!legacyState) {
+                assertEquals(request.getReplyId(), start.getReplyId());
+            }
+            assertEquals(0, tool.executions.get());
+            assertEquals(
+                    1L,
+                    agent.getAgentState().getContext().stream()
+                            .flatMap(m -> m.getContentBlocks(ToolResultBlock.class).stream())
+                            .filter(
+                                    r ->
+                                            "tc1".equals(r.getId())
+                                                    && r.getState() == ToolResultState.DENIED)
+                            .count());
+        }
+    }
+
+    @Test
+    void mixedDenialsAndPartialConfirmationEmitEachResultOnce() {
+        AskingTool first = new AskingTool("first");
+        AskingTool second = new AskingTool("second");
+        AskingTool blocked =
+                new AskingTool("blocked") {
+                    @Override
+                    public Mono<PermissionDecision> checkPermissions(
+                            Map<String, Object> input, PermissionContextState context) {
+                        return Mono.just(PermissionDecision.deny("blocked"));
+                    }
+                };
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () ->
+                                        Flux.just(
+                                                toolUseResponse(
+                                                        List.of(
+                                                                ToolUseBlock.builder()
+                                                                        .id("tc1")
+                                                                        .name("first")
+                                                                        .input(Map.of("query", "x"))
+                                                                        .build(),
+                                                                ToolUseBlock.builder()
+                                                                        .id("tc2")
+                                                                        .name("second")
+                                                                        .input(Map.of("query", "y"))
+                                                                        .build(),
+                                                                ToolUseBlock.builder()
+                                                                        .id("tc3")
+                                                                        .name("blocked")
+                                                                        .input(Map.of("query", "z"))
+                                                                        .build()))),
+                                () -> Flux.just(textResponse("done"))));
+        try (ReActAgent agent = buildAgent(model, toolkitWith(first, second, blocked))) {
+            List<AgentEvent> paused = agent.streamEvents(List.of()).collectList().block();
+            assertDeniedEvents(paused, "tc3", "blocked", "Permission denied by rules");
+            RequireUserConfirmEvent request =
+                    (RequireUserConfirmEvent)
+                            paused.get(indexOf(paused, RequireUserConfirmEvent.class));
+            assertTrue(
+                    indexOf(paused, ToolResultEndEvent.class)
+                            < indexOf(paused, RequireUserConfirmEvent.class));
+            assertEquals(
+                    request.getReplyId(),
+                    ((ToolResultStartEvent) paused.get(indexOf(paused, ToolResultStartEvent.class)))
+                            .getReplyId());
+            List<AgentEvent> partial =
+                    agent.streamEvents(
+                                    List.of(
+                                            confirmMsg(
+                                                    false,
+                                                    request.getToolCalls().stream()
+                                                            .filter(t -> "tc1".equals(t.getId()))
+                                                            .findFirst()
+                                                            .orElseThrow())))
+                            .collectList()
+                            .block();
+            assertDeniedEvents(partial, "tc1", "first", "Permission denied by user");
+            assertEquals(
+                    request.getReplyId(),
+                    ((ToolResultStartEvent)
+                                    partial.get(indexOf(partial, ToolResultStartEvent.class)))
+                            .getReplyId());
+            RequireUserConfirmEvent remaining =
+                    (RequireUserConfirmEvent)
+                            partial.get(indexOf(partial, RequireUserConfirmEvent.class));
+            assertEquals(
+                    List.of("tc2"),
+                    remaining.getToolCalls().stream().map(ToolUseBlock::getId).toList());
+            List<AgentEvent> completed =
+                    agent.streamEvents(List.of(confirmMsg(true, remaining.getToolCalls().get(0))))
+                            .collectList()
+                            .block();
+            List<ToolResultEndEvent> ends =
+                    completed.stream()
+                            .filter(ToolResultEndEvent.class::isInstance)
+                            .map(ToolResultEndEvent.class::cast)
+                            .toList();
+            assertEquals(
+                    remaining.getReplyId(),
+                    ((UserConfirmResultEvent)
+                                    completed.get(indexOf(completed, UserConfirmResultEvent.class)))
+                            .getReplyId());
+            assertEquals(1, ends.size());
+            assertEquals("tc2", ends.get(0).getToolCallId());
+            assertEquals(ToolResultState.SUCCESS, ends.get(0).getState());
+            assertEquals(0, first.executions.get());
+            assertEquals(0, blocked.executions.get());
+            assertEquals(1, second.executions.get());
+        }
+    }
+
+    private static void assertDeniedEvents(
+            List<AgentEvent> events, String id, String name, String text) {
+        List<AgentEvent> results =
+                events.stream()
+                        .filter(
+                                e ->
+                                        e instanceof ToolResultStartEvent
+                                                || e instanceof ToolResultTextDeltaEvent
+                                                || e instanceof ToolResultEndEvent)
+                        .toList();
+        assertEquals(3, results.size(), "one complete result sequence must be emitted");
+        assertTrue(results.get(0) instanceof ToolResultStartEvent);
+        assertTrue(results.get(1) instanceof ToolResultTextDeltaEvent);
+        assertTrue(results.get(2) instanceof ToolResultEndEvent);
+        ToolResultStartEvent start = (ToolResultStartEvent) results.get(0);
+        ToolResultTextDeltaEvent delta = (ToolResultTextDeltaEvent) results.get(1);
+        ToolResultEndEvent end = (ToolResultEndEvent) results.get(2);
+        assertEquals(id, start.getToolCallId());
+        assertEquals(id, delta.getToolCallId());
+        assertEquals(id, end.getToolCallId());
+        assertEquals(name, start.getToolCallName());
+        assertEquals(name, delta.getToolCallName());
+        assertEquals(name, end.getToolCallName());
+        assertEquals(start.getReplyId(), delta.getReplyId());
+        assertEquals(start.getReplyId(), end.getReplyId());
+        assertEquals(text, delta.getDelta());
+        assertEquals(ToolResultState.DENIED, end.getState());
     }
 
     @Test

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
@@ -232,6 +232,14 @@ public class AguiStreamContext {
         }
     }
 
+    /** Recognize a validated permission resume without replaying the previous run's call events. */
+    public void resumeToolCall(String toolCallId) {
+        if (!isBlank(toolCallId)) {
+            startedToolCalls.add(toolCallId);
+            endedToolCalls.add(toolCallId);
+        }
+    }
+
     public void beginToolResult(String toolCallId) {
         if (!hasStartedToolCall(toolCallId, "ToolResultStartEvent")) {
             return;

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/PermissionConfirmEventConverter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/PermissionConfirmEventConverter.java
@@ -25,6 +25,7 @@ import static io.agentscope.core.agui.AguiInterruptConstants.TOOL_CALL_INTERRUPT
 
 import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.ConfirmResult;
 import io.agentscope.core.event.RequireUserConfirmEvent;
 import io.agentscope.core.event.UserConfirmResultEvent;
 import io.agentscope.core.message.ToolUseBlock;
@@ -54,7 +55,8 @@ import java.util.Set;
  * {@code ToolUseBlock}, and tool-input validation reads {@code content} directly with no fallback to
  * {@code input}; a null content would fail the resume with {@code argument "content" is null}.
  *
- * <p>{@link UserConfirmResultEvent} is intentionally registered here as a no-op.
+ * <p>{@link UserConfirmResultEvent} restores tool-call tracking for confirmations validated by
+ * the agent. The original call events belong to the previous run and are not emitted again.
  */
 final class PermissionConfirmEventConverter implements AgentEventConverter {
 
@@ -82,7 +84,12 @@ final class PermissionConfirmEventConverter implements AgentEventConverter {
 
     @Override
     public void convert(AgentEvent event, AguiStreamContext context) {
-        if (event instanceof UserConfirmResultEvent) {
+        if (event instanceof UserConfirmResultEvent resultEvent) {
+            for (ConfirmResult result : resultEvent.getConfirmResults()) {
+                if (result.getToolCall() != null) {
+                    context.resumeToolCall(result.getToolCall().getId());
+                }
+            }
             return;
         }
         RequireUserConfirmEvent confirmEvent = (RequireUserConfirmEvent) event;

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
@@ -1418,6 +1418,30 @@ class AguiAgentAdapterV2Test {
         }
 
         @Test
+        void testPermissionResumeOnlyRestoresConfirmedToolIds() {
+            ToolUseBlock confirmed = ToolUseBlock.builder().id("tool-1").name("lookup").build();
+            List<AguiEvent> events =
+                    runReActEvents(
+                            new UserConfirmResultEvent(
+                                    "reply-confirm", List.of(new ConfirmResult(false, confirmed))),
+                            new ToolResultStartEvent("reply-confirm", "tool-2", "unrelated"),
+                            new ToolResultTextDeltaEvent(
+                                    "reply-confirm", "tool-2", "unrelated", "ignored"),
+                            new ToolResultEndEvent(
+                                    "reply-confirm", "tool-2", "unrelated", ToolResultState.DENIED),
+                            new ToolResultStartEvent("reply-confirm", "tool-1", "lookup"),
+                            new ToolResultTextDeltaEvent(
+                                    "reply-confirm",
+                                    "tool-1",
+                                    "lookup",
+                                    "Permission denied by user"),
+                            new ToolResultEndEvent(
+                                    "reply-confirm", "tool-1", "lookup", ToolResultState.DENIED));
+            assertEquals(List.of(AguiEventType.TOOL_CALL_RESULT), types(events));
+            assertToolCallResult(events.get(0), "tool-1", "Permission denied by user");
+        }
+
+        @Test
         void testWarnMissingToolCallIdDeduplicatesByEventName() throws Exception {
             AguiStreamContext context =
                     new AguiStreamContext("thread-v2", "run-v2", AguiAdapterConfig.defaultConfig());

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiPermissionResumeIntegrationTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiPermissionResumeIntegrationTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.core.agui.adapter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.agui.model.AguiMessage;
+import io.agentscope.core.agui.model.AguiResume;
+import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatModelBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionDecision;
+import io.agentscope.core.tool.ToolBase;
+import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.Toolkit;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+class AguiPermissionResumeIntegrationTest {
+    @ParameterizedTest
+    @CsvSource({"false,false", "false,true", "true,false", "true,true"})
+    void confirmationResumeEmitsResultAcrossRuns(boolean approved, boolean legacyState) {
+        AtomicInteger executions = new AtomicInteger();
+        Toolkit toolkit = new Toolkit();
+        toolkit.registerAgentTool(
+                new ToolBase(
+                        "echo",
+                        "echo",
+                        Map.of(
+                                "type",
+                                "object",
+                                "properties",
+                                Map.of("message", Map.of("type", "string"))),
+                        false,
+                        true,
+                        false,
+                        null,
+                        false,
+                        false) {
+                    @Override
+                    public Mono<PermissionDecision> checkPermissions(
+                            Map<String, Object> input, PermissionContextState context) {
+                        return Mono.just(PermissionDecision.ask("confirm echo"));
+                    }
+
+                    @Override
+                    public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
+                        executions.incrementAndGet();
+                        return Mono.just(ToolResultBlock.text("echoed"));
+                    }
+                });
+        AtomicInteger modelCalls = new AtomicInteger();
+        ChatModelBase model =
+                new ChatModelBase() {
+                    @Override
+                    public String getModelName() {
+                        return "scripted";
+                    }
+
+                    @Override
+                    protected Flux<ChatResponse> doStream(
+                            List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+                        return Flux.just(
+                                ChatResponse.builder()
+                                        .content(
+                                                modelCalls.getAndIncrement() == 0
+                                                        ? List.of(
+                                                                ToolUseBlock.builder()
+                                                                        .id("tc1")
+                                                                        .name("echo")
+                                                                        .input(
+                                                                                Map.of(
+                                                                                        "message",
+                                                                                        "hello"))
+                                                                        .build())
+                                                        : List.of(
+                                                                TextBlock.builder()
+                                                                        .text("done")
+                                                                        .build()))
+                                        .build());
+                    }
+                };
+        try (ReActAgent agent =
+                ReActAgent.builder().name("assistant").model(model).toolkit(toolkit).build()) {
+            AguiAgentAdapter adapter =
+                    new AguiAgentAdapter(agent, AguiAdapterConfig.defaultConfig());
+            List<AguiEvent> paused =
+                    adapter.run(
+                                    RunAgentInput.builder()
+                                            .threadId("permission-thread")
+                                            .runId("first-run")
+                                            .messages(
+                                                    List.of(
+                                                            AguiMessage.userMessage(
+                                                                    "msg-1", "echo hello")))
+                                            .build())
+                            .collectList()
+                            .block();
+            assertNotNull(paused);
+            AguiEvent.RunFinished finished =
+                    paused.stream()
+                            .filter(AguiEvent.RunFinished.class::isInstance)
+                            .map(AguiEvent.RunFinished.class::cast)
+                            .findFirst()
+                            .orElseThrow();
+            AguiEvent.Interrupt interrupt =
+                    assertInstanceOf(
+                                    AguiEvent.RunFinishedInterruptOutcome.class, finished.outcome())
+                            .interrupts()
+                            .get(0);
+            if (legacyState) {
+                List<Msg> context = agent.getAgentState(null, "permission-thread").contextMutable();
+                for (int i = 0; i < context.size(); i++) {
+                    Msg msg = context.get(i);
+                    Map<String, Object> metadata = new HashMap<>(msg.getMetadata());
+                    metadata.remove(Msg.METADATA_CONFIRM_REQUEST_REPLY_ID);
+                    context.set(i, msg.withMetadata(metadata));
+                }
+            }
+            List<AguiEvent> resumed =
+                    adapter.run(
+                                    RunAgentInput.builder()
+                                            .threadId("permission-thread")
+                                            .runId("second-run")
+                                            .messages(List.of())
+                                            .resume(
+                                                    List.of(
+                                                            new AguiResume(
+                                                                    interrupt.id(),
+                                                                    AguiResume.STATUS_RESOLVED,
+                                                                    Map.of("approved", approved))))
+                                            .build(),
+                                    RuntimeContext.builder()
+                                            .put(
+                                                    AguiAgentAdapter
+                                                            .RUNTIME_CONTEXT_RESUME_INTERRUPTS_KEY,
+                                                    Map.of(interrupt.id(), interrupt))
+                                            .build())
+                            .collectList()
+                            .block();
+            assertNotNull(resumed);
+            assertFalse(resumed.stream().anyMatch(AguiEvent.RunError.class::isInstance));
+            List<AguiEvent.ToolCallResult> results =
+                    resumed.stream()
+                            .filter(AguiEvent.ToolCallResult.class::isInstance)
+                            .map(AguiEvent.ToolCallResult.class::cast)
+                            .toList();
+            assertEquals(1, results.size(), "the resumed run must deliver the tool outcome");
+            assertEquals("tc1", results.get(0).toolCallId());
+            assertEquals(
+                    approved ? "echoed" : "Permission denied by user", results.get(0).content());
+            assertEquals("second-run", results.get(0).runId());
+            assertFalse(
+                    resumed.stream().anyMatch(AguiEvent.ToolCallStart.class::isInstance),
+                    "resuming must not replay the original tool call lifecycle");
+            assertFalse(resumed.stream().anyMatch(AguiEvent.ToolCallEnd.class::isInstance));
+            assertEquals(approved ? 1 : 0, executions.get());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3097

User-denied permission confirmations previously updated the message context without emitting tool-result events, leaving event-driven clients without a tool outcome.

This change:
- Emits the complete start → text delta → end (DENIED) sequence for user denials.
- Emits rule-denied results in batches that also contain tools awaiting confirmation.
- Restores validated tool-call tracking on AG-UI resume without replaying call start/end events.
- Supports older sessions without persisted confirmation reply IDs.

Validation:
- Core: 2,338 tests, 9 skipped.
- Harness: 1,030 tests, 14 skipped.
- AG-UI: 413 tests.
- Zero failures or errors; formatting and diff checks passed.
-