### PR TITLE
fix(agui): preserve tool results after permission resume

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/AguiStreamContext.java
@@ -53,6 +53,7 @@ public class AguiStreamContext {
     private final Set<String> endedReasoningMessages = new LinkedHashSet<>();
     private final Set<String> startedToolCalls = new LinkedHashSet<>();
     private final Set<String> endedToolCalls = new LinkedHashSet<>();
+    private final Set<String> adoptedToolCalls = new LinkedHashSet<>();
     private String currentTextMessageId;
     private String currentReasoningMessageId;
     private final Map<String, StringBuilder> toolResultContent = new LinkedHashMap<>();
@@ -232,15 +233,33 @@ public class AguiStreamContext {
         }
     }
 
+    /**
+     * Accept results for a tool call whose invocation was emitted in a previous run.
+     *
+     * <p>Callers must obtain the id from a known pending tool call, such as a validated user
+     * confirmation. Adoption is idempotent and emits no events. It does not start a tool call in
+     * this run, enable argument events, or clear an existing result buffer. Null or blank ids are
+     * ignored, just as they are for tool-call events.
+     *
+     * @param toolCallId stable id of the previously emitted tool call
+     */
+    public void adoptToolCall(String toolCallId) {
+        if (isBlank(toolCallId)) {
+            warnMissingToolCallId("adoptToolCall");
+            return;
+        }
+        adoptedToolCalls.add(toolCallId);
+    }
+
     public void beginToolResult(String toolCallId) {
-        if (!hasStartedToolCall(toolCallId, "ToolResultStartEvent")) {
+        if (!hasKnownToolCall(toolCallId, "ToolResultStartEvent")) {
             return;
         }
         toolResultContent.computeIfAbsent(toolCallId, ignored -> new StringBuilder());
     }
 
     public void appendToolResultText(String toolCallId, String delta) {
-        if (!hasStartedToolCall(toolCallId, "ToolResultTextDeltaEvent")) {
+        if (!hasKnownToolCall(toolCallId, "ToolResultTextDeltaEvent")) {
             return;
         }
         if (delta != null && !delta.isEmpty()) {
@@ -249,7 +268,7 @@ public class AguiStreamContext {
     }
 
     public void appendToolResultData(String toolCallId, ContentBlock data) {
-        if (!hasStartedToolCall(toolCallId, "ToolResultDataDeltaEvent")) {
+        if (!hasKnownToolCall(toolCallId, "ToolResultDataDeltaEvent")) {
             return;
         }
         if (data == null) {
@@ -263,10 +282,10 @@ public class AguiStreamContext {
     }
 
     public void endToolResult(String replyId, String toolCallId) {
-        if (!hasStartedToolCall(toolCallId, "ToolResultEndEvent")) {
+        if (!hasKnownToolCall(toolCallId, "ToolResultEndEvent")) {
             return;
         }
-        if (endedToolCalls.add(toolCallId)) {
+        if (startedToolCalls.contains(toolCallId) && endedToolCalls.add(toolCallId)) {
             emit(new AguiEvent.ToolCallEnd(threadId, runId, toolCallId));
         }
         StringBuilder content = toolResultContent.remove(toolCallId);
@@ -281,7 +300,7 @@ public class AguiStreamContext {
     }
 
     public void markToolCallSuspended(String toolCallId) {
-        if (!hasStartedToolCall(toolCallId, "ToolResultEndEvent")) {
+        if (!hasKnownToolCall(toolCallId, "ToolResultEndEvent")) {
             return;
         }
         toolResultContent.remove(toolCallId);
@@ -314,6 +333,10 @@ public class AguiStreamContext {
             return false;
         }
         return startedToolCalls.contains(toolCallId);
+    }
+
+    private boolean hasKnownToolCall(String toolCallId, String eventName) {
+        return hasStartedToolCall(toolCallId, eventName) || adoptedToolCalls.contains(toolCallId);
     }
 
     private StringBuilder toolResultBuffer(String toolCallId) {

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/PermissionConfirmEventConverter.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/adapter/strategy/PermissionConfirmEventConverter.java
@@ -25,6 +25,7 @@ import static io.agentscope.core.agui.AguiInterruptConstants.TOOL_CALL_INTERRUPT
 
 import io.agentscope.core.agui.event.AguiEvent;
 import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.ConfirmResult;
 import io.agentscope.core.event.RequireUserConfirmEvent;
 import io.agentscope.core.event.UserConfirmResultEvent;
 import io.agentscope.core.message.ToolUseBlock;
@@ -54,7 +55,9 @@ import java.util.Set;
  * {@code ToolUseBlock}, and tool-input validation reads {@code content} directly with no fallback to
  * {@code input}; a null content would fail the resume with {@code argument "content" is null}.
  *
- * <p>{@link UserConfirmResultEvent} is intentionally registered here as a no-op.
+ * <p>{@link UserConfirmResultEvent} silently adopts the validated tool-call ids so the new run
+ * can deliver their results without replaying the previous run's tool-call events. Core emits
+ * this event after validating the confirmation against its pending tool calls.
  */
 final class PermissionConfirmEventConverter implements AgentEventConverter {
 
@@ -82,7 +85,12 @@ final class PermissionConfirmEventConverter implements AgentEventConverter {
 
     @Override
     public void convert(AgentEvent event, AguiStreamContext context) {
-        if (event instanceof UserConfirmResultEvent) {
+        if (event instanceof UserConfirmResultEvent resultEvent) {
+            for (ConfirmResult result : resultEvent.getConfirmResults()) {
+                if (result.getToolCall() != null) {
+                    context.adoptToolCall(result.getToolCall().getId());
+                }
+            }
             return;
         }
         RequireUserConfirmEvent confirmEvent = (RequireUserConfirmEvent) event;

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/adapter/AguiAgentAdapterV2Test.java
@@ -1406,6 +1406,86 @@ class AguiAgentAdapterV2Test {
         }
 
         @Test
+        void testConfirmedToolResultsFromPreviousRunAreEmittedWithoutToolCallEvents() {
+            ToolUseBlock toolUse = ToolUseBlock.builder().id("tool-1").name("lookup").build();
+            UserConfirmResultEvent confirmation =
+                    new UserConfirmResultEvent(
+                            "previous-reply", List.of(new ConfirmResult(true, toolUse)));
+            List<AguiEvent> events =
+                    runReActEvents(
+                            confirmation,
+                            new ToolResultStartEvent("resumed-reply", "tool-1", "lookup"),
+                            new ToolResultTextDeltaEvent(
+                                    "resumed-reply", "tool-1", "lookup", "text"),
+                            confirmation,
+                            new ToolResultDataDeltaEvent(
+                                    "resumed-reply",
+                                    "tool-1",
+                                    "lookup",
+                                    TextBlock.builder().text("data").build()),
+                            new ToolCallDeltaEvent("previous-reply", "tool-1", "lookup", "{}"),
+                            new ToolCallEndEvent("previous-reply", "tool-1", "lookup"),
+                            new ToolResultEndEvent("resumed-reply", "tool-1", "lookup", null));
+
+            assertEquals(List.of(AguiEventType.TOOL_CALL_RESULT), types(events));
+            assertToolCallResult(events.get(0), "tool-1", "text\ndata");
+            assertEquals(
+                    "resumed-reply:tool-1", ((AguiEvent.ToolCallResult) events.get(0)).messageId());
+        }
+
+        @Test
+        void testConfirmedToolSuspensionDiscardsPartialResultWithoutEmittingToolCallEnd() {
+            ToolUseBlock toolUse = ToolUseBlock.builder().id("tool-1").name("lookup").build();
+            List<AguiEvent> events =
+                    runReActEvents(
+                            new UserConfirmResultEvent(
+                                    "previous-reply", List.of(new ConfirmResult(true, toolUse))),
+                            new ToolResultStartEvent("resumed-reply", "tool-1", "lookup"),
+                            new ToolResultTextDeltaEvent(
+                                    "resumed-reply", "tool-1", "lookup", "partial"),
+                            new ToolResultEndEvent(
+                                    "resumed-reply", "tool-1", "lookup", ToolResultState.RUNNING),
+                            new ToolResultStartEvent("resumed-reply", "tool-1", "lookup"),
+                            new ToolResultTextDeltaEvent(
+                                    "resumed-reply", "tool-1", "lookup", "final"),
+                            new ToolResultEndEvent("resumed-reply", "tool-1", "lookup", null));
+
+            assertEquals(List.of(AguiEventType.TOOL_CALL_RESULT), types(events));
+            assertToolCallResult(events.get(0), "tool-1", "final");
+        }
+
+        @Test
+        void testAdoptionIsSilentAndLocalToTheStreamContext() {
+            AguiStreamContext context =
+                    new AguiStreamContext(
+                            "thread", "resumed-run", AguiAdapterConfig.defaultConfig());
+            context.adoptToolCall(null);
+            context.adoptToolCall(" ");
+            context.adoptToolCall("resumed-tool");
+            context.adoptToolCall("resumed-tool");
+            assertTrue(context.drainEvents().isEmpty());
+            assertTrue(context.finishPendingEvents().isEmpty());
+            context.endToolResult("reply", null);
+            context.endToolResult("reply", " ");
+            assertTrue(context.drainEvents().isEmpty());
+
+            context.startToolCall("current-tool", "lookup");
+            context.adoptToolCall("current-tool");
+            context.drainEvents();
+            assertEquals(
+                    List.of(AguiEventType.TOOL_CALL_END), types(context.finishPendingEvents()));
+            context.endToolResult("reply", "resumed-tool");
+            List<AguiEvent> result = context.drainEvents();
+            assertEquals(List.of(AguiEventType.TOOL_CALL_RESULT), types(result));
+            assertToolCallResult(result.get(0), "resumed-tool", null);
+
+            AguiStreamContext nextRun =
+                    new AguiStreamContext("thread", "next-run", AguiAdapterConfig.defaultConfig());
+            nextRun.endToolResult("reply", "resumed-tool");
+            assertTrue(nextRun.drainEvents().isEmpty());
+        }
+
+        @Test
         void testToolResultEventsWithoutStartedToolCallAreIgnored() {
             List<AguiEvent> events =
                     runReActEvents(

--- a/agentscope-harness/pom.xml
+++ b/agentscope-harness/pom.xml
@@ -45,6 +45,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Exercise AG-UI resume conversion against the real HarnessAgent. -->
+        <dependency>
+            <groupId>io.agentscope</groupId>
+            <artifactId>agentscope-extensions-agui</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- YAML parsing for subagent config -->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/AguiPermissionResumeTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/AguiPermissionResumeTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.agent.Agent;
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.agui.adapter.AguiAdapterConfig;
+import io.agentscope.core.agui.adapter.strategy.AgentEventConverterRegistry;
+import io.agentscope.core.agui.adapter.strategy.AguiStreamContext;
+import io.agentscope.core.agui.event.AguiEvent;
+import io.agentscope.core.agui.model.AguiMessage;
+import io.agentscope.core.agui.model.AguiResume;
+import io.agentscope.core.agui.model.RunAgentInput;
+import io.agentscope.core.agui.processor.AgentResolver;
+import io.agentscope.core.agui.processor.AguiRequestProcessor;
+import io.agentscope.core.agui.runtime.AguiRuntimeContextRequest;
+import io.agentscope.core.event.AgentEvent;
+import io.agentscope.core.event.ConfirmResult;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.message.ToolResultBlock;
+import io.agentscope.core.message.ToolUseBlock;
+import io.agentscope.core.model.ChatModelBase;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.GenerateOptions;
+import io.agentscope.core.model.ToolSchema;
+import io.agentscope.core.permission.PermissionContextState;
+import io.agentscope.core.permission.PermissionDecision;
+import io.agentscope.core.state.InMemoryAgentStateStore;
+import io.agentscope.core.tool.ToolBase;
+import io.agentscope.core.tool.ToolCallParam;
+import io.agentscope.core.tool.Toolkit;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/** Exercises two real agent runs, with deterministic model and tool implementations. */
+class AguiPermissionResumeTest {
+
+    @TempDir Path workspace;
+
+    @ParameterizedTest(name = "harness={0}, officialResume={1}")
+    @CsvSource({"false,true", "true,true", "false,false", "true,false"})
+    void approvedToolResultSurvivesNewStreamContext(boolean harness, boolean officialResume) {
+        ScriptedModel model = new ScriptedModel();
+        AskingTool tool = new AskingTool();
+        Toolkit toolkit = new Toolkit();
+        toolkit.registerAgentTool(tool);
+        InMemoryAgentStateStore store = new InMemoryAgentStateStore();
+        Agent agent =
+                harness
+                        ? HarnessAgent.builder()
+                                .name("resume-test")
+                                .model(model)
+                                .toolkit(toolkit)
+                                .workspace(workspace)
+                                .stateStore(store)
+                                .permissionContext(PermissionContextState.builder().build())
+                                .build()
+                        : ReActAgent.builder()
+                                .name("resume-test")
+                                .model(model)
+                                .toolkit(toolkit)
+                                .stateStore(store)
+                                .build();
+        try {
+            AguiRequestProcessor processor =
+                    AguiRequestProcessor.builder()
+                            .agentResolver(
+                                    new AgentResolver() {
+                                        @Override
+                                        public Agent resolveAgent(String agentId, String threadId) {
+                                            return agent;
+                                        }
+
+                                        @Override
+                                        public boolean hasMemory(RuntimeContext context) {
+                                            return true;
+                                        }
+                                    })
+                            .build();
+            List<AguiEvent> first =
+                    run(
+                            processor,
+                            input("first")
+                                    .messages(
+                                            List.of(
+                                                    AguiMessage.userMessage(
+                                                            "user-1", "Run the tool")))
+                                    .build());
+            assertNoError(first);
+            AguiEvent.RunFinished paused =
+                    assertInstanceOf(AguiEvent.RunFinished.class, first.get(first.size() - 1));
+            AguiEvent.RunFinishedInterruptOutcome outcome =
+                    assertInstanceOf(AguiEvent.RunFinishedInterruptOutcome.class, paused.outcome());
+            assertEquals(1, outcome.interrupts().size());
+            AguiEvent.Interrupt interrupt = outcome.interrupts().get(0);
+            assertEquals("tc1", interrupt.toolCallId());
+            assertEquals(0, tool.calls.get(), "tool must wait for approval");
+            assertEquals(
+                    1, first.stream().filter(AguiEvent.ToolCallStart.class::isInstance).count());
+            assertEquals(1, first.stream().filter(AguiEvent.ToolCallEnd.class::isInstance).count());
+            assertTrue(first.stream().noneMatch(AguiEvent.ToolCallResult.class::isInstance));
+
+            List<AguiEvent> resumed;
+            if (officialResume) {
+                resumed =
+                        run(
+                                processor,
+                                input("second")
+                                        .resume(
+                                                List.of(
+                                                        new AguiResume(
+                                                                interrupt.id(),
+                                                                AguiResume.STATUS_RESOLVED,
+                                                                Map.of("approved", true))))
+                                        .build());
+            } else {
+                // Applications can also submit ConfirmResult directly to the event-stream API.
+                Msg confirmation =
+                        Msg.builder()
+                                .role(MsgRole.USER)
+                                .textContent("approved")
+                                .metadata(
+                                        Map.of(
+                                                Msg.METADATA_CONFIRM_RESULTS,
+                                                List.of(new ConfirmResult(true, toolCall()))))
+                                .build();
+                RuntimeContext runtime =
+                        RuntimeContext.builder().sessionId("resume-thread").build();
+                Flux<AgentEvent> source =
+                        harness
+                                ? ((HarnessAgent) agent)
+                                        .streamEvents(List.of(confirmation), runtime)
+                                : ((ReActAgent) agent).streamEvents(List.of(confirmation), runtime);
+                AgentEventConverterRegistry registry = new AgentEventConverterRegistry();
+                AguiStreamContext context =
+                        new AguiStreamContext(
+                                "resume-thread", "second", AguiAdapterConfig.defaultConfig());
+                resumed =
+                        source.concatMapIterable(event -> registry.convert(event, context))
+                                .concatWith(
+                                        Flux.defer(
+                                                () ->
+                                                        Flux.fromIterable(
+                                                                context.finishPendingEvents())))
+                                .collectList()
+                                .block(Duration.ofSeconds(20));
+            }
+            assertNoError(resumed);
+            List<AguiEvent.ToolCallResult> results =
+                    resumed.stream()
+                            .filter(AguiEvent.ToolCallResult.class::isInstance)
+                            .map(AguiEvent.ToolCallResult.class::cast)
+                            .toList();
+            assertEquals(1, results.size(), "resumed run must deliver the original tool result");
+            assertEquals("tc1", results.get(0).toolCallId());
+            assertEquals("executed:ping", results.get(0).content());
+            assertEquals("second", results.get(0).runId());
+            assertTrue(
+                    resumed.stream()
+                            .noneMatch(
+                                    event ->
+                                            event instanceof AguiEvent.ToolCallStart
+                                                    || event instanceof AguiEvent.ToolCallArgs
+                                                    || event instanceof AguiEvent.ToolCallEnd));
+            assertInstanceOf(AguiEvent.RunFinished.class, resumed.get(resumed.size() - 1));
+            assertEquals(1, tool.calls.get());
+        } finally {
+            if (agent instanceof HarnessAgent harnessAgent) {
+                harnessAgent.close();
+            } else {
+                ((ReActAgent) agent).close();
+            }
+        }
+    }
+
+    private static RunAgentInput.Builder input(String runId) {
+        return RunAgentInput.builder().threadId("resume-thread").runId(runId).messages(List.of());
+    }
+
+    private static List<AguiEvent> run(AguiRequestProcessor processor, RunAgentInput input) {
+        return processor
+                .process(AguiRuntimeContextRequest.builder().input(input).build())
+                .events()
+                .collectList()
+                .block(Duration.ofSeconds(20));
+    }
+
+    private static void assertNoError(List<AguiEvent> events) {
+        assertNotNull(events);
+        assertTrue(
+                events.stream().noneMatch(AguiEvent.RunError.class::isInstance), events.toString());
+    }
+
+    private static ToolUseBlock toolCall() {
+        return ToolUseBlock.builder()
+                .id("tc1")
+                .name("approval_test_tool")
+                .input(Map.of("query", "ping"))
+                .content("{\"query\":\"ping\"}")
+                .build();
+    }
+
+    private static final class ScriptedModel extends ChatModelBase {
+        private final AtomicInteger calls = new AtomicInteger();
+
+        @Override
+        public String getModelName() {
+            return "scripted";
+        }
+
+        @Override
+        protected Flux<ChatResponse> doStream(
+                List<Msg> messages, List<ToolSchema> tools, GenerateOptions options) {
+            return Flux.just(
+                    ChatResponse.builder()
+                            .content(
+                                    calls.getAndIncrement() == 0
+                                            ? List.of(toolCall())
+                                            : List.of(TextBlock.builder().text("done").build()))
+                            .build());
+        }
+    }
+
+    private static final class AskingTool extends ToolBase {
+        private final AtomicInteger calls = new AtomicInteger();
+
+        AskingTool() {
+            super(
+                    "approval_test_tool",
+                    "requires approval",
+                    Map.of(
+                            "type",
+                            "object",
+                            "properties",
+                            Map.of("query", Map.of("type", "string"))),
+                    false,
+                    true,
+                    false,
+                    null,
+                    false,
+                    false);
+        }
+
+        @Override
+        public Mono<PermissionDecision> checkPermissions(
+                Map<String, Object> input, PermissionContextState context) {
+            return Mono.just(PermissionDecision.ask("approve this tool"));
+        }
+
+        @Override
+        public Mono<ToolResultBlock> callAsync(ToolCallParam param) {
+            calls.incrementAndGet();
+            return Mono.just(ToolResultBlock.text("executed:" + param.getInput().get("query")));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3096

After permission approval, a resumed run executes the pending tool but drops its result because the new AguiStreamContext does not recognize the previous run's toolCallId.

Adopt validated tool-call IDs when handling UserConfirmResultEvent, allowing the resumed run to emit TOOL_CALL_RESULT without replaying TOOL_CALL_START/ARGS/END. Unknown IDs remain ignored, and adopted IDs stay local to the current stream context.

Validation:
- Added 7 regression cases covering result aggregation, suspension, context isolation, and real ReActAgent/HarnessAgent approval round trips.
- Full Core, AG-UI, and Harness suites: 3,875 tests, 0 failures, 0 errors, 23 skipped.
- Spotless and git diff --check passed.