### PR TITLE
feat(harness): expose HttpClient injection for built-in web tools

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgent.java
@@ -122,6 +122,7 @@ import io.agentscope.harness.agent.workspace.WorkspaceIndex;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
 import io.agentscope.harness.agent.workspace.WorkspacePathNormalizer;
 import io.agentscope.harness.agent.workspace.plan.PlanModeManager;
+import java.net.http.HttpClient;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -1244,6 +1245,10 @@ public class HarnessAgent implements Agent, AutoCloseable {
         boolean disableFilesystemTools = false;
         boolean disableShellTool = false;
         boolean disableWebTools = false;
+
+        /** Optional caller-supplied client used by the built-in web tools; {@code null} = default. */
+        HttpClient webHttpClient;
+
         boolean disableMemoryTools = false;
         boolean disableMemoryHooks = false;
         boolean disableTranscript = false;
@@ -2058,6 +2063,18 @@ public class HarnessAgent implements Agent, AutoCloseable {
         }
 
         /**
+         * Supplies a custom {@link java.net.http.HttpClient} used by the built-in {@code web_fetch}
+         * and {@code web_search} tools (e.g. custom proxy, TLS or HTTP version settings). When
+         * unset, the tools use a default client with JDK version negotiation (HTTP/2 preferred,
+         * automatic HTTP/1.1 fallback); inject an HTTP/1.1-only client here if a target server
+         * fails under HTTP/2 negotiation (see issue #3101).
+         */
+        public Builder webHttpClient(HttpClient client) {
+            this.webHttpClient = client;
+            return this;
+        }
+
+        /**
          * Registers schema-only external tools on the builder toolkit (merged into the final
          * agent toolkit at {@link #build()}). Used by {@code self_hosted} environments to expose
          * hands tools that suspend for worker execution.
@@ -2691,8 +2708,13 @@ public class HarnessAgent implements Agent, AutoCloseable {
                 agentToolkit.registerTool(new ShellExecuteTool(sandbox));
             }
             if (!disableWebTools) {
-                agentToolkit.registerTool(new WebTools.WebFetchTool());
-                agentToolkit.registerTool(new WebTools.WebSearchTool());
+                if (webHttpClient != null) {
+                    agentToolkit.registerTool(new WebTools.WebFetchTool(webHttpClient));
+                    agentToolkit.registerTool(new WebTools.WebSearchTool(webHttpClient));
+                } else {
+                    agentToolkit.registerTool(new WebTools.WebFetchTool());
+                    agentToolkit.registerTool(new WebTools.WebSearchTool());
+                }
             }
 
             // ---- Plan mode (read-only design phase) ----

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/HarnessAgentBuilderSupport.java
@@ -339,6 +339,7 @@ final class HarnessAgentBuilderSupport {
         final boolean capturedDisableShellTool = b.disableShellTool;
         final boolean capturedDisableMemoryTools = b.disableMemoryTools;
         final boolean capturedDisableMemoryHooks = b.disableMemoryHooks;
+        final var capturedWebHttpClient = b.webHttpClient;
         final boolean capturedDisableSessionPersistence = b.disableSessionPersistence;
         final boolean capturedDisableWorkspaceContext = b.disableWorkspaceContext;
         final boolean capturedPlanModeEnabled = b.planModeEnabled;
@@ -394,6 +395,7 @@ final class HarnessAgentBuilderSupport {
             if (capturedDisableShellTool) sub.disableShellTool();
             if (capturedDisableMemoryTools) sub.disableMemoryTools();
             if (capturedDisableMemoryHooks) sub.disableMemoryHooks();
+            if (capturedWebHttpClient != null) sub.webHttpClient(capturedWebHttpClient);
             if (capturedDisableSessionPersistence) sub.disableSessionPersistence();
             if (capturedDisableWorkspaceContext) sub.disableWorkspaceContext();
             configurePlanMode(
@@ -459,6 +461,7 @@ final class HarnessAgentBuilderSupport {
         final boolean capturedDisableShellTool = b.disableShellTool;
         final boolean capturedDisableMemoryTools = b.disableMemoryTools;
         final boolean capturedDisableMemoryHooks = b.disableMemoryHooks;
+        final var capturedWebHttpClient = b.webHttpClient;
         final boolean capturedDisableSessionPersistence = b.disableSessionPersistence;
         final boolean capturedPlanModeEnabled = b.planModeEnabled;
         final boolean capturedPlanModeAllowShell = b.planModeAllowShell;
@@ -562,6 +565,7 @@ final class HarnessAgentBuilderSupport {
             if (capturedDisableShellTool) sub.disableShellTool();
             if (capturedDisableMemoryTools) sub.disableMemoryTools();
             if (capturedDisableMemoryHooks) sub.disableMemoryHooks();
+            if (capturedWebHttpClient != null) sub.webHttpClient(capturedWebHttpClient);
             if (capturedDisableSessionPersistence) sub.disableSessionPersistence();
             configurePlanMode(
                     sub, capturedPlanModeEnabled, capturedPlanModeAllowShell, capturedPlanFileDir);

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/WebTools.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/WebTools.java
@@ -24,6 +24,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Objects;
 
 /**
  * Builtin web tools ({@code web_fetch}, {@code web_search}) for Managed Agents / Harness.
@@ -35,9 +36,29 @@ public final class WebTools {
 
     private WebTools() {}
 
+    /**
+     * Default client for the built-in web tools. Uses the JDK's default version negotiation
+     * (HTTP/2 preferred, transparently falling back to HTTP/1.1 when the server does not support
+     * it). If a target server misbehaves under HTTP/2 negotiation and returns empty responses
+     * (e.g. {@code HTTP/1.1 header parser received no bytes}, see issue #3101), inject an
+     * HTTP/1.1-only client via the {@code WebFetchTool(HttpClient)} / {@code WebSearchTool(HttpClient)}
+     * constructors or {@code HarnessAgent.Builder#webHttpClient(HttpClient)}.
+     */
+    static HttpClient createDefaultHttpClient() {
+        return HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(20)).build();
+    }
+
     public static final class WebFetchTool {
-        private final HttpClient client =
-                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(20)).build();
+        private final HttpClient client;
+
+        public WebFetchTool() {
+            this(createDefaultHttpClient());
+        }
+
+        /** Creates a tool that uses a caller-supplied client (custom proxy, SSL, HTTP version, ...). */
+        public WebFetchTool(HttpClient client) {
+            this.client = Objects.requireNonNull(client, "client");
+        }
 
         @Tool(
                 name = "web_fetch",
@@ -89,8 +110,16 @@ public final class WebTools {
     public static final class WebSearchTool {
         private static final String TAVILY_API = "https://api.tavily.com/search";
         private final ObjectMapper mapper = new ObjectMapper();
-        private final HttpClient client =
-                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(20)).build();
+        private final HttpClient client;
+
+        public WebSearchTool() {
+            this(createDefaultHttpClient());
+        }
+
+        /** Creates a tool that uses a caller-supplied client (custom proxy, SSL, HTTP version, ...). */
+        public WebSearchTool(HttpClient client) {
+            this.client = Objects.requireNonNull(client, "client");
+        }
 
         @Tool(
                 name = "web_search",

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSubagentStreamTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentSubagentStreamTest.java
@@ -38,6 +38,7 @@ import io.agentscope.core.model.ChatResponse;
 import io.agentscope.core.model.Model;
 import io.agentscope.harness.agent.filesystem.local.LocalFilesystem;
 import io.agentscope.harness.agent.testing.HarnessQuiescence;
+import java.net.http.HttpClient;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -384,6 +385,66 @@ class HarnessAgentSubagentStreamTest {
         assertNotNull(reply, "reply must not be null");
         assertTrue(
                 reply.getTextContent().contains("result obtained"),
+                "final reply text mismatch; got: " + reply.getTextContent());
+    }
+
+    /**
+     * A custom {@link java.net.http.HttpClient} configured on the parent builder must be inherited
+     * by spawned subagents: {@code buildDeclaredFactory} captures {@code b.webHttpClient} and
+     * forwards it onto the child builder.
+     */
+    @Test
+    void call_localSubagent_inheritsCustomWebHttpClient() throws Exception {
+        String childId = "webclient-child";
+        Files.createDirectories(workspace.resolve("subagents"));
+        Files.writeString(
+                workspace.resolve("subagents/" + childId + ".md"),
+                """
+                ---
+                description: Web client child
+                ---
+                You are a helper.
+                """);
+
+        Model model = mock(Model.class);
+        when(model.getModelName()).thenReturn("stub");
+        when(model.stream(anyList(), any(), any()))
+                .thenReturn(
+                        Flux.just(
+                                toolCallChunk(
+                                        "p1",
+                                        "agent_spawn",
+                                        Map.of(
+                                                "agent_id",
+                                                childId,
+                                                "task",
+                                                "check",
+                                                "timeout_seconds",
+                                                60))))
+                .thenReturn(Flux.just(stopChunk("c1", "child done")))
+                .thenReturn(Flux.just(stopChunk("p2", "parent done")));
+
+        parent =
+                HarnessAgent.builder()
+                        .name("parent")
+                        .model(model)
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .webHttpClient(
+                                HttpClient.newBuilder()
+                                        .version(HttpClient.Version.HTTP_1_1)
+                                        .build())
+                        .build();
+
+        Msg reply =
+                parent.call(
+                                List.of(Msg.builder().role(MsgRole.USER).textContent("go").build()),
+                                RuntimeContext.builder().sessionId("sess-webclient").build())
+                        .block();
+
+        assertNotNull(reply, "reply must not be null");
+        assertTrue(
+                reply.getTextContent().contains("parent done"),
                 "final reply text mismatch; got: " + reply.getTextContent());
     }
 

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/HarnessAgentTest.java
@@ -68,6 +68,7 @@ import io.agentscope.harness.agent.subagent.WorkspaceMode;
 import io.agentscope.harness.agent.testing.HarnessQuiescence;
 import io.agentscope.harness.agent.workspace.WorkspaceConstants;
 import java.io.IOException;
+import java.net.http.HttpClient;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -247,6 +248,31 @@ class HarnessAgentTest {
                         .toList();
         assertFalse(toolNames.contains("web_search"));
         assertFalse(toolNames.contains("web_fetch"));
+    }
+
+    @Test
+    void webHttpClient_injectsCustomClient() throws Exception {
+        Files.createDirectories(workspace);
+        HttpClient custom =
+                HttpClient.newBuilder()
+                        .version(HttpClient.Version.HTTP_1_1)
+                        .connectTimeout(Duration.ofSeconds(10))
+                        .build();
+        HarnessAgent agent =
+                HarnessAgent.builder()
+                        .name("t")
+                        .model(stubModel("ok"))
+                        .workspace(workspace)
+                        .abstractFilesystem(new LocalFilesystem(workspace))
+                        .webHttpClient(custom)
+                        .build();
+
+        List<String> toolNames =
+                agent.getDelegate().getToolkit().getToolSchemas().stream()
+                        .map(ToolSchema::getName)
+                        .toList();
+        assertTrue(toolNames.contains("web_search"));
+        assertTrue(toolNames.contains("web_fetch"));
     }
 
     @Test

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/WebToolsTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/tool/WebToolsTest.java
@@ -18,13 +18,20 @@ package io.agentscope.harness.agent.tool;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import com.sun.net.httpserver.HttpServer;
 import io.agentscope.core.message.ToolResultBlock;
 import io.agentscope.core.message.ToolResultState;
 import io.agentscope.core.message.ToolUseBlock;
 import io.agentscope.core.tool.ToolCallParam;
 import io.agentscope.core.tool.Toolkit;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -63,5 +70,64 @@ class WebToolsTest {
                 call(new WebTools.WebSearchTool(), "web_search", Map.of("query", "industry"));
         assertNotNull(result);
         assertEquals(ToolResultState.ERROR, result.getState());
+    }
+
+    @Test
+    void defaultClientUsesJdkVersionNegotiation() {
+        HttpClient client = WebTools.createDefaultHttpClient();
+        // No version pinned: JDK default HTTP/2 preferred, automatic HTTP/1.1 fallback.
+        assertEquals(HttpClient.Version.HTTP_2, client.version());
+    }
+
+    @Test
+    void defaultClientFetchesFromHttp11Server() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(
+                "/",
+                exchange -> {
+                    byte[] body = "hello from http/1.1".getBytes(StandardCharsets.UTF_8);
+                    exchange.sendResponseHeaders(200, body.length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(body);
+                    }
+                });
+        server.start();
+        try {
+            String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+            String out = new WebTools.WebFetchTool().webFetch(url, null);
+            assertTrue(out.contains("hello from http/1.1"));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void nullClientIsRejected() {
+        assertThrows(NullPointerException.class, () -> new WebTools.WebFetchTool(null));
+        assertThrows(NullPointerException.class, () -> new WebTools.WebSearchTool(null));
+    }
+
+    @Test
+    void customHttpClientIsUsed() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext(
+                "/",
+                exchange -> {
+                    byte[] body = "custom client hit".getBytes(StandardCharsets.UTF_8);
+                    exchange.sendResponseHeaders(200, body.length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(body);
+                    }
+                });
+        server.start();
+        try {
+            HttpClient custom =
+                    HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
+            String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+            String out = new WebTools.WebFetchTool(custom).webFetch(url, null);
+            assertTrue(out.contains("custom client hit"));
+        } finally {
+            server.stop(0);
+        }
     }
 }


### PR DESCRIPTION
## AgentScope-Java Version

`2.0.3`

## Description

Fixes #3101

### Summary

Expose caller-supplied `java.net.http.HttpClient` injection for the built-in
`web_fetch` / `web_search` tools so users can work around servers that
misbehave under HTTP/2 negotiation. The default client is unchanged (JDK
version negotiation: HTTP/2 preferred with automatic HTTP/1.1 fallback);
users who hit HTTP/1.1-only servers can now inject an HTTP/1.1 client via the
new constructors or `HarnessAgent.Builder.webHttpClient(...)`.

### Background

Issue #3101: `WebFetchTool` fails with
`HTTP/1.1 header parser received no bytes` against a file server that does
not support HTTP/2. The built-in tools hard-code their `HttpClient`
(`HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(20)).build()`),
which uses the JDK default HTTP/2; the tool exposes no way to customise the
client. A local override with `version(HTTP_1_1)` was confirmed to work by
the reporter. This PR closes that gap by making the client injectable while
keeping the existing default behaviour fully backwards compatible.

### Changes

- `agentscope-harness` `WebTools.java`: extract package-private
  `createDefaultHttpClient()` (JDK default version negotiation + 20s connect
  timeout); add `WebFetchTool(HttpClient)` / `WebSearchTool(HttpClient)`
  constructor overloads (no-arg constructors keep the original behaviour).
- `agentscope-harness` `HarnessAgent.java`: add
  `Builder.webHttpClient(HttpClient)` setter and pass it through when
  registering the built-in web tools in `build()`.
- `agentscope-harness` `HarnessAgentBuilderSupport.java`: propagate the custom
  client when building subagents (general-purpose + declared factories).
- Tests: 6 new tests covering custom-client injection, the default
  negotiation-mode client, HTTP/1.1 fallback against a local server, null
  rejection, and the HarnessAgent/subagent propagation path.

### How to test

```bash
mvn -pl agentscope-harness test -Dtest=WebToolsTest,HarnessAgentTest,HarnessAgentSubagentStreamTest
```

## Checklist

Please check the following items before code is ready to be reviewed.

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [ ] Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review
