### PR TITLE
fix(core): emit tool result events for user-denied HITL calls

### DIFF
--- a/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
+++ b/agentscope-core/src/main/java/io/agentscope/core/ReActAgent.java
@@ -1913,7 +1913,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                 clearPendingRequestReplyId(Msg.METADATA_CONFIRM_REQUEST_REPLY_ID);
             }
 
-            applyConfirmResults(normalized);
+            applyConfirmResults(normalized, replyId);
         }
 
         /** Resolve the reply id for the pending HITL request stored on the last assistant message. */
@@ -1978,7 +1978,7 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
          *       the tool will no longer be pending on resume.</li>
          * </ul>
          */
-        private void applyConfirmResults(List<ConfirmResult> results) {
+        private void applyConfirmResults(List<ConfirmResult> results, String replyId) {
             // Replace ASKING ToolUseBlocks with possibly-modified ones from the user, and
             // promote them to ALLOWED. Collect denied ones for separate handling.
             List<ToolUseBlock> deniedToolCalls = new ArrayList<>();
@@ -2011,6 +2011,22 @@ public class ReActAgent extends AgentBase implements AutoCloseable {
                         ToolResultMessageBuilder.buildToolResultMsg(
                                 deniedResult, denied, getName());
                 state.contextMutable().add(deniedMsg);
+                if (replyId != null && !replyId.isEmpty()) {
+                    publishEvent(
+                            new ToolResultStartEvent(replyId, denied.getId(), denied.getName()));
+                    publishEvent(
+                            new ToolResultTextDeltaEvent(
+                                    replyId,
+                                    denied.getId(),
+                                    denied.getName(),
+                                    "Permission denied by user"));
+                    publishEvent(
+                            new ToolResultEndEvent(
+                                    replyId,
+                                    denied.getId(),
+                                    denied.getName(),
+                                    ToolResultState.DENIED));
+                }
             }
         }
 

--- a/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
+++ b/agentscope-core/src/test/java/io/agentscope/core/agent/ReActAgentHitlTest.java
@@ -26,6 +26,8 @@ import io.agentscope.core.event.ConfirmResult;
 import io.agentscope.core.event.RequestStopEvent;
 import io.agentscope.core.event.RequireUserConfirmEvent;
 import io.agentscope.core.event.ToolResultEndEvent;
+import io.agentscope.core.event.ToolResultStartEvent;
+import io.agentscope.core.event.ToolResultTextDeltaEvent;
 import io.agentscope.core.event.UserConfirmResultEvent;
 import io.agentscope.core.message.ContentBlock;
 import io.agentscope.core.message.GenerateReason;
@@ -328,6 +330,39 @@ class ReActAgentHitlTest {
         assertEquals(req.getReplyId(), confirm.getReplyId());
         assertEquals(1, confirm.getConfirmResults().size());
         assertEquals("tc1", confirm.getConfirmResults().get(0).getToolCall().getId());
+    }
+
+    @Test
+    void deniedResumeEmitsToolResultEventsCorrelatedToRequireEvent() {
+        ChatModelBase model =
+                new ScriptedModel(
+                        List.of(
+                                () -> Flux.just(toolUseResponse("tc1", "ask", "x")),
+                                () -> Flux.just(textResponse("done"))));
+        ReActAgent agent = buildAgent(model, toolkitWith(new AskingTool("ask")));
+
+        List<AgentEvent> pauseEvents = agent.streamEvents(List.of()).collectList().block();
+        assertNotNull(pauseEvents);
+        RequireUserConfirmEvent req =
+                (RequireUserConfirmEvent)
+                        pauseEvents.get(indexOf(pauseEvents, RequireUserConfirmEvent.class));
+
+        List<AgentEvent> resumeEvents =
+                agent.streamEvents(List.of(confirmMsg(false, req.getToolCalls().get(0))))
+                        .collectList()
+                        .block();
+        assertNotNull(resumeEvents);
+
+        int iStart = indexOf(resumeEvents, ToolResultStartEvent.class);
+        int iDelta = indexOf(resumeEvents, ToolResultTextDeltaEvent.class);
+        int iEnd = indexOf(resumeEvents, ToolResultEndEvent.class);
+        assertTrue(iStart >= 0, "denied resume must emit ToolResultStartEvent");
+        assertTrue(iDelta > iStart, "denied resume must emit a result delta");
+        assertTrue(iEnd > iDelta, "denied resume must emit ToolResultEndEvent");
+        ToolResultEndEvent end = (ToolResultEndEvent) resumeEvents.get(iEnd);
+        assertEquals(req.getReplyId(), end.getReplyId());
+        assertEquals("tc1", end.getToolCallId());
+        assertEquals(ToolResultState.DENIED, end.getState());
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

When a user denies a permission-mode HITL tool call, the resumed run writes a DENIED ToolResultBlock to context but emits no ToolResultStartEvent/ToolResultTextDeltaEvent/ToolResultEndEvent. This leaves AG-UI and other event-driven consumers unable to observe the outcome. Rule-denied calls already emit the corresponding sequence.

### What changed

- Carry the persisted HITL reply id into confirmation-result application.
- Emit the same start → text delta → end sequence for user-denied calls, with `ToolResultState.DENIED`.
- Add an end-to-end regression test covering correlation, ordering, tool-call id, and denied state.

### Verification

- `mvn -pl agentscope-core -DskipTests -Dspotless.check.skip=false spotless:check`
- `mvn -pl agentscope-core -Dtest=ReActAgentHitlTest test` (14 tests passed)

Signed-off-by: Yohanes <CryoThrust@users.noreply.github.com>