### PR TITLE
fix(agui): clear active-run marker before terminal signal propagation

### DIFF
--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/main/java/io/agentscope/core/agui/processor/AguiRequestProcessor.java
@@ -196,6 +196,22 @@ public class AguiRequestProcessor {
                                                             event,
                                                             runErrorSeen.get());
                                                 })
+                                        // Finish the run before the terminal signal reaches
+                                        // the caller. doFinally runs after onComplete/onError
+                                        // is propagated, so a caller that collected this run's
+                                        // events and immediately started the next run on the
+                                        // same thread (the common resume flow) could observe
+                                        // the stale active-run marker and be rejected with
+                                        // AGUI_INTERRUPT_CONTRACT_ERROR. doOnComplete/doOnError
+                                        // run before propagation, giving a happens-before
+                                        // guarantee; finishRun is idempotent, and doFinally
+                                        // still covers the cancellation path.
+                                        .doOnComplete(
+                                                () -> resumeCoordinator.finishRun(threadId, runId))
+                                        .doOnError(
+                                                error ->
+                                                        resumeCoordinator.finishRun(
+                                                                threadId, runId))
                                         .doFinally(
                                                 signalType ->
                                                         resumeCoordinator.finishRun(

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -323,6 +324,34 @@ class AguiRequestProcessorTest {
             assertEquals(2, adapterCount.get());
         } finally {
             nextRun.dispose();
+        }
+    }
+
+    @Test
+    void processAllowsImmediateFollowUpRunAfterPreviousRunTerminates() {
+        // Regression guard for a CI-observed flake in AguiPermissionResumeTest: the
+        // active-run marker used to be cleared in doFinally, which runs after the
+        // terminal signal is propagated. A caller that collected the first run's events
+        // and immediately started the next run on the same thread could therefore be
+        // rejected with "Thread already has an active run". finishRun must happen
+        // before the terminal signal reaches the caller; it is idempotent, and the
+        // doFinally hook still covers the cancellation path.
+        AgentResolver resolver = mock(AgentResolver.class);
+        ReActAgent agent = mock(ReActAgent.class);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
+        when(agent.streamEvents(anyList(), any(RuntimeContext.class)))
+                .thenReturn(Flux.just(new AgentEndEvent("reply")));
+        AguiRequestProcessor processor =
+                AguiRequestProcessor.builder().agentResolver(resolver).build();
+
+        for (int i = 0; i < 20; i++) {
+            List<AguiEvent> events =
+                    processor.process(request(input("run-" + i))).events().collectList().block();
+            assertNotNull(events);
+            assertTrue(
+                    events.stream().noneMatch(AguiEvent.RunError.class::isInstance),
+                    () -> "follow-up run was rejected: " + events);
         }
     }
 

--- a/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
+++ b/agentscope-extensions/agentscope-extensions-protocol/agentscope-extensions-agui/src/test/java/io/agentscope/core/agui/processor/AguiRequestProcessorTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -353,6 +354,81 @@ class AguiRequestProcessorTest {
                     events.stream().noneMatch(AguiEvent.RunError.class::isInstance),
                     () -> "follow-up run was rejected: " + events);
         }
+    }
+
+    @Test
+    void processAllowsImmediateFollowUpRunAfterInStreamRunError() {
+        // An in-stream failure is converted by the adapter into a RunError event on a
+        // normally-completing stream. The active-run marker must already be cleared when
+        // the caller sees the terminal signal (doOnComplete path), so an immediate
+        // follow-up run on the same thread can start despite the error.
+        AgentResolver resolver = mock(AgentResolver.class);
+        ReActAgent agent = mock(ReActAgent.class);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
+        AtomicInteger calls = new AtomicInteger();
+        when(agent.streamEvents(anyList(), any(RuntimeContext.class)))
+                .thenAnswer(
+                        inv ->
+                                calls.getAndIncrement() == 0
+                                        ? Flux.error(new IllegalStateException("boom"))
+                                        : Flux.just(new AgentEndEvent("recovered")));
+        AguiRequestProcessor processor =
+                AguiRequestProcessor.builder().agentResolver(resolver).build();
+
+        List<AguiEvent> failed =
+                processor.process(request(input("run-0"))).events().collectList().block();
+        assertNotNull(failed);
+        assertTrue(
+                failed.stream().anyMatch(AguiEvent.RunError.class::isInstance),
+                () -> "expected an in-stream RunError: " + failed);
+
+        List<AguiEvent> followUp =
+                processor.process(request(input("run-1"))).events().collectList().block();
+        assertNotNull(followUp);
+        assertTrue(
+                followUp.stream().noneMatch(AguiEvent.RunError.class::isInstance),
+                () -> "follow-up run was rejected: " + followUp);
+    }
+
+    @Test
+    void processClearsActiveRunWhenAdapterStreamFailsWithErrorSignal() {
+        // Defense-in-depth contract for doOnError: if an adapter's stream fails with a
+        // raw error signal (escaping the adapter's own error-to-RunError conversion),
+        // the marker must be cleared before the error reaches the caller, so an
+        // immediate follow-up run on the same thread can start.
+        AgentResolver resolver = mock(AgentResolver.class);
+        ReActAgent agent = mock(ReActAgent.class);
+        when(resolver.resolveAgent(eq("default"), eq("thread-1"), nullable(String.class)))
+                .thenReturn(agent);
+        AtomicInteger adapterRuns = new AtomicInteger();
+        AguiAgentAdapter failingAdapter =
+                new AguiAgentAdapter(agent, AguiAdapterConfig.defaultConfig()) {
+                    @Override
+                    public Flux<AguiEvent> run(RunAgentInput input, RuntimeContext context) {
+                        // Only the first run fails with a raw error signal; the follow-up
+                        // run must find the marker cleared and start normally.
+                        return adapterRuns.getAndIncrement() == 0
+                                ? Flux.error(new IllegalStateException("adapter stream failed"))
+                                : Flux.empty();
+                    }
+                };
+        AguiRequestProcessor processor =
+                AguiRequestProcessor.builder()
+                        .agentResolver(resolver)
+                        .adapterFactory((resolvedAgent, config) -> failingAdapter)
+                        .build();
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> processor.process(request(input("run-1"))).events().collectList().block());
+
+        List<AguiEvent> followUp =
+                processor.process(request(input("run-2"))).events().collectList().block();
+        assertNotNull(followUp);
+        assertTrue(
+                followUp.stream().noneMatch(AguiEvent.RunError.class::isInstance),
+                () -> "follow-up run was rejected: " + followUp);
     }
 
     @Test


### PR DESCRIPTION
## 问题

AG-UI 线程的 active-run 标记在 `doFinally` 中清除，而 `doFinally` 的执行时机是**终止信号传播给订阅者之后**。调用方收集完一个 run 的事件后立即在同一 thread 上发起下一个 run——这正是标准的 resume 流程——此时可能观察到残留的标记，被拒绝并收到：

```
RunError[message=Thread already has an active run; wait for run <id> to finish before starting another run on the same thread, code=AGUI_INTERRUPT_CONTRACT_ERROR]
```

尽管上一个 run 从调用方视角已经完全结束。

该问题已在本仓库的 CI 上间歇性复现：`AguiPermissionResumeTest` 在 PR #2858 的分支（一次 Update branch 之后）以及 main 分支自身（如 2026-09-09 `d20ebbe0` 的 `Java CI with Maven`）都失败过。本地同一 commit 复跑 3/3 全部通过——这正是时序竞态的典型表现：CI runner 越慢，竞态窗口越大。

## 根因

`AguiRequestProcessor.process` 中：

- `resumeCoordinator.beginRun(input)` 注册 thread 的活跃 run（`putIfAbsent`）；
- 标记仅由 `.doFinally(signal -> finishRun(threadId, runId))` 清除；
- `doFinally` 的清理在 `onComplete`/`onError` 向下游传播**之后**执行，因此 `finishRun` 与调用方随后的 `beginRun` 之间没有 happens-before 保证。

## 修复

改为在 `doOnComplete` / `doOnError` 中清除标记——它们在终止信号到达调用方**之前**执行，为 `finishRun` 与后续 `beginRun` 之间建立 happens-before 保证。`finishRun` 是幂等的（`remove(key, value)`）；`doFinally` 钩子保留作为 cancel 路径的兜底（cancel 无法在信号传播前拦截）。

## 测试

- 新增回归测试 `processAllowsImmediateFollowUpRunAfterPreviousRunTerminates`：同 thread 连续 20 次立即发起新 run，断言无 `RunError`——把传播契约钉成可执行断言；
- `agentscope-extensions-agui`：507 个测试全部通过；
- `agentscope-core`（经 `-am` 联动构建）：2335 个测试全部通过。
