### PR TITLE
fix: fail early for incompatible Redisson state-store clients

### DIFF
--- a/agentscope-extensions/agentscope-extensions-redis/src/main/java/io/agentscope/extensions/redis/state/redisson/RedissonAgentStateStore.java
+++ b/agentscope-extensions/agentscope-extensions-redis/src/main/java/io/agentscope/extensions/redis/state/redisson/RedissonAgentStateStore.java
@@ -66,6 +66,7 @@ public class RedissonAgentStateStore implements AgentStateStore {
     private static final String LIST_SUFFIX = ":list";
 
     private final RedissonClient redissonClient;
+    private final RScript.ReturnType scriptReturnType;
     private final String keyPrefix;
 
     private RedissonAgentStateStore(Builder builder) {
@@ -74,6 +75,19 @@ public class RedissonAgentStateStore implements AgentStateStore {
         }
         if (builder.redissonClient == null) {
             throw new IllegalArgumentException("RedissonClient cannot be null");
+        }
+        try {
+            this.scriptReturnType = RScript.ReturnType.valueOf("LONG");
+        } catch (IllegalArgumentException e) {
+            String version = RScript.class.getPackage().getImplementationVersion();
+            throw new IllegalStateException(
+                    "Redisson state-store integration requires the Redisson 4.x API"
+                            + " (RScript.ReturnType.LONG); Redisson 3.x is incompatible."
+                            + " Align your Redisson dependencies, including any starter, with"
+                            + " the project's currently managed version 4.2.0."
+                            + " Loaded Redisson API implementation version: "
+                            + (version == null ? "unknown" : version),
+                    e);
         }
         this.keyPrefix = builder.keyPrefix;
         this.redissonClient = builder.redissonClient;
@@ -150,7 +164,7 @@ public class RedissonAgentStateStore implements AgentStateStore {
                             .eval(
                                     RScript.Mode.READ_WRITE,
                                     RedisStateVersionSupport.SAVE_SCRIPT,
-                                    RScript.ReturnType.LONG,
+                                    scriptReturnType,
                                     new ArrayList<>(scriptKeys),
                                     scriptArgs.toArray());
             long newVersion = ((Number) result).longValue();

--- a/agentscope-extensions/agentscope-extensions-redis/src/main/java/io/agentscope/extensions/redis/state/redisson/RedissonClientAdapter.java
+++ b/agentscope-extensions/agentscope-extensions-redis/src/main/java/io/agentscope/extensions/redis/state/redisson/RedissonClientAdapter.java
@@ -119,8 +119,22 @@ import org.redisson.client.codec.StringCodec;
 public class RedissonClientAdapter implements RedisClientAdapter {
 
     private final RedissonClient redissonClient;
+    private final RScript.ReturnType scriptReturnType;
 
     private RedissonClientAdapter(RedissonClient redissonClient) {
+        try {
+            this.scriptReturnType = RScript.ReturnType.valueOf("LONG");
+        } catch (IllegalArgumentException e) {
+            String version = RScript.class.getPackage().getImplementationVersion();
+            throw new IllegalStateException(
+                    "Redisson state-store integration requires the Redisson 4.x API"
+                            + " (RScript.ReturnType.LONG); Redisson 3.x is incompatible."
+                            + " Align your Redisson dependencies, including any starter, with"
+                            + " the project's currently managed version 4.2.0."
+                            + " Loaded Redisson API implementation version: "
+                            + (version == null ? "unknown" : version),
+                    e);
+        }
         this.redissonClient = redissonClient;
     }
 
@@ -225,7 +239,7 @@ public class RedissonClientAdapter implements RedisClientAdapter {
                         .eval(
                                 RScript.Mode.READ_WRITE,
                                 script,
-                                RScript.ReturnType.LONG,
+                                scriptReturnType,
                                 keyObjects,
                                 args.toArray());
         if (result instanceof Number number) {

--- a/agentscope-extensions/agentscope-extensions-redis/src/test/java/io/agentscope/extensions/redis/state/redisson/RedissonAgentStateStoreTest.java
+++ b/agentscope-extensions/agentscope-extensions-redis/src/test/java/io/agentscope/extensions/redis/state/redisson/RedissonAgentStateStoreTest.java
@@ -15,33 +15,44 @@
  */
 package io.agentscope.extensions.redis.state.redisson;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.agentscope.core.state.AgentStateStore;
 import io.agentscope.core.state.State;
+import io.agentscope.extensions.redis.state.RedisStateVersionSupport;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
 import org.redisson.api.RScript;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.Codec;
+import org.redisson.client.codec.StringCodec;
 
 /**
- * Unit tests for {@link RedissonAgentStateStore} optimistic-concurrency versioning.
+ * Unit tests for {@link RedissonAgentStateStore} compatibility and optimistic-concurrency versioning.
  *
  * <p>Uses Mockito to mock Redisson resources so no real Redis server is required. This test
- * covers the {@code saveIfVersion} UNVERSIONED path, which was the single uncovered line in the
- * deprecated Redisson store.
+ * covers construction and the {@code saveIfVersion} UNVERSIONED regression in the deprecated store.
  */
-@DisplayName("RedissonAgentStateStore versioning")
+@DisplayName("RedissonAgentStateStore compatibility and versioning")
 class RedissonAgentStateStoreTest {
 
     record TestState(String value) implements State {}
@@ -51,6 +62,119 @@ class RedissonAgentStateStoreTest {
     @BeforeEach
     void setUp() {
         redissonClient = mock(RedissonClient.class);
+    }
+
+    @Test
+    void constructsWithoutContactingRedis() {
+        assertDoesNotThrow(
+                () -> RedissonAgentStateStore.builder().redissonClient(redissonClient).build());
+        verifyNoInteractions(redissonClient);
+    }
+
+    @Test
+    void rejectsIncompatibleApiBeforeContactingRedis() {
+        IllegalArgumentException cause = new IllegalArgumentException("No enum constant LONG");
+        try (MockedStatic<RScript.ReturnType> returnType = mockStatic(RScript.ReturnType.class)) {
+            returnType.when(() -> RScript.ReturnType.valueOf("LONG")).thenThrow(cause);
+
+            IllegalStateException error =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () ->
+                                    RedissonAgentStateStore.builder()
+                                            .redissonClient(redissonClient)
+                                            .build());
+
+            assertSame(cause, error.getCause());
+            assertTrue(error.getMessage().contains("requires the Redisson 4.x API"));
+            assertTrue(error.getMessage().contains("Redisson 3.x is incompatible"));
+            assertTrue(
+                    error.getMessage()
+                            .contains("Align your Redisson dependencies, including any starter"));
+            assertTrue(error.getMessage().contains("4.2.0"));
+            String version = RScript.class.getPackage().getImplementationVersion();
+            assertTrue(
+                    error.getMessage()
+                            .contains(
+                                    "Loaded Redisson API implementation version: "
+                                            + (version == null ? "unknown" : version)));
+            verifyNoInteractions(redissonClient);
+        }
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t"})
+    void validatesPrefixBeforeResolvingReturnType(String prefix) {
+        try (MockedStatic<RScript.ReturnType> returnType = mockStatic(RScript.ReturnType.class)) {
+            IllegalArgumentException error =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () ->
+                                    RedissonAgentStateStore.builder()
+                                            .keyPrefix(prefix)
+                                            .redissonClient(redissonClient)
+                                            .build());
+            assertEquals("Key prefix cannot be null or empty", error.getMessage());
+            returnType.verifyNoInteractions();
+            verifyNoInteractions(redissonClient);
+        }
+    }
+
+    @Test
+    void validatesClientBeforeResolvingReturnType() {
+        try (MockedStatic<RScript.ReturnType> returnType = mockStatic(RScript.ReturnType.class)) {
+            IllegalArgumentException error =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> RedissonAgentStateStore.builder().build());
+            assertEquals("RedissonClient cannot be null", error.getMessage());
+            returnType.verifyNoInteractions();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {6L, -1L})
+    void saveIfVersionPreservesVersionAndConflictResults(long result) {
+        RedissonAgentStateStore store =
+                RedissonAgentStateStore.builder()
+                        .redissonClient(redissonClient)
+                        .keyPrefix("test:")
+                        .build();
+        RScript script = mock(RScript.class);
+        RScript.ReturnType longReturnType = RScript.ReturnType.valueOf("LONG");
+        List<Object> keys =
+                List.of(
+                        "test:user/session:agent_state",
+                        "test:user/session:agent_state:ver",
+                        "test:user/session:_keys");
+        when(redissonClient.getScript(StringCodec.INSTANCE)).thenReturn(script);
+        when(script.eval(
+                        RScript.Mode.READ_WRITE,
+                        RedisStateVersionSupport.SAVE_SCRIPT,
+                        longReturnType,
+                        keys,
+                        "{\"value\":\"v\"}",
+                        "5",
+                        "agent_state"))
+                .thenReturn(result);
+
+        try (MockedStatic<RScript.ReturnType> returnType = mockStatic(RScript.ReturnType.class)) {
+            assertEquals(
+                    result == -1L ? AgentStateStore.UNVERSIONED : result,
+                    store.saveIfVersion("user", "session", "agent_state", new TestState("v"), 5L));
+            returnType.verifyNoInteractions();
+        }
+        verify(redissonClient).getScript(StringCodec.INSTANCE);
+        verify(script)
+                .eval(
+                        RScript.Mode.READ_WRITE,
+                        RedisStateVersionSupport.SAVE_SCRIPT,
+                        longReturnType,
+                        keys,
+                        "{\"value\":\"v\"}",
+                        "5",
+                        "agent_state");
     }
 
     @Test
@@ -82,6 +206,19 @@ class RedissonAgentStateStoreTest {
                         AgentStateStore.UNVERSIONED);
 
         assertEquals(5L, version);
+        verify(redissonClient).getScript(StringCodec.INSTANCE);
+        verify(rScript)
+                .eval(
+                        RScript.Mode.READ_WRITE,
+                        RedisStateVersionSupport.SAVE_SCRIPT,
+                        RScript.ReturnType.valueOf("LONG"),
+                        List.of(
+                                "test:user/session:agent_state",
+                                "test:user/session:agent_state:ver",
+                                "test:user/session:_keys"),
+                        "{\"value\":\"v\"}",
+                        RedisStateVersionSupport.UNCONDITIONAL,
+                        "agent_state");
         // Regression: the UNVERSIONED path must not call getVersioned (which reads back as
         // State.class — a marker interface Jackson cannot instantiate).
         verify(redissonClient, never()).getBucket(any(), any());

--- a/agentscope-extensions/agentscope-extensions-redis/src/test/java/io/agentscope/extensions/redis/state/redisson/RedissonClientAdapterTest.java
+++ b/agentscope-extensions/agentscope-extensions-redis/src/test/java/io/agentscope/extensions/redis/state/redisson/RedissonClientAdapterTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.extensions.redis.state.redisson;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.extensions.redis.state.RedisAgentStateStore;
+import io.agentscope.extensions.redis.state.RedisClientAdapter;
+import java.math.BigInteger;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.redisson.api.RScript;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+
+class RedissonClientAdapterTest {
+
+    private RedissonClient redissonClient;
+
+    @BeforeEach
+    void setUp() {
+        redissonClient = mock(RedissonClient.class);
+    }
+
+    @Test
+    void constructsAdapterAndUnifiedStoreWithoutContactingRedis() {
+        assertDoesNotThrow(() -> RedissonClientAdapter.of(redissonClient));
+        assertDoesNotThrow(
+                () -> RedisAgentStateStore.builder().redissonClient(redissonClient).build());
+        verifyNoInteractions(redissonClient);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void rejectsIncompatibleApiAtPublicConstructionBoundary(boolean throughBuilder) {
+        IllegalArgumentException cause = new IllegalArgumentException("No enum constant LONG");
+        try (MockedStatic<RScript.ReturnType> returnType = mockStatic(RScript.ReturnType.class)) {
+            returnType.when(() -> RScript.ReturnType.valueOf("LONG")).thenThrow(cause);
+
+            IllegalStateException error =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> {
+                                if (throughBuilder) {
+                                    RedisAgentStateStore.builder().redissonClient(redissonClient);
+                                } else {
+                                    RedissonClientAdapter.of(redissonClient);
+                                }
+                            });
+
+            assertSame(cause, error.getCause());
+            assertTrue(error.getMessage().contains("requires the Redisson 4.x API"));
+            assertTrue(error.getMessage().contains("Redisson 3.x is incompatible"));
+            assertTrue(
+                    error.getMessage()
+                            .contains("Align your Redisson dependencies, including any starter"));
+            assertTrue(error.getMessage().contains("4.2.0"));
+            String version = RScript.class.getPackage().getImplementationVersion();
+            assertTrue(
+                    error.getMessage()
+                            .contains(
+                                    "Loaded Redisson API implementation version: "
+                                            + (version == null ? "unknown" : version)));
+            verifyNoInteractions(redissonClient);
+        }
+    }
+
+    @Test
+    void customAdapterDoesNotResolveRedissonReturnType() {
+        RedisClientAdapter client = mock(RedisClientAdapter.class);
+        try (MockedStatic<RScript.ReturnType> returnType = mockStatic(RScript.ReturnType.class)) {
+            assertDoesNotThrow(() -> RedisAgentStateStore.builder().clientAdapter(client).build());
+            returnType.verifyNoInteractions();
+            verifyNoInteractions(client);
+        }
+    }
+
+    @Test
+    void evalScriptDelegatesWithResolvedReturnTypeAndConvertsNumbers() {
+        RedissonClientAdapter adapter = RedissonClientAdapter.of(redissonClient);
+        RScript script = mock(RScript.class);
+        RScript.ReturnType longReturnType = RScript.ReturnType.valueOf("LONG");
+        when(redissonClient.getScript(StringCodec.INSTANCE)).thenReturn(script);
+        when(script.eval(
+                        RScript.Mode.READ_WRITE,
+                        "return ARGV[1]",
+                        longReturnType,
+                        List.of("key1", "key2"),
+                        "arg1",
+                        "arg2"))
+                .thenReturn(42L, 7, BigInteger.valueOf(9));
+
+        try (MockedStatic<RScript.ReturnType> returnType = mockStatic(RScript.ReturnType.class)) {
+            assertEquals(
+                    42L,
+                    adapter.evalScript(
+                            "return ARGV[1]", List.of("key1", "key2"), List.of("arg1", "arg2")));
+            assertEquals(
+                    7L,
+                    adapter.evalScript(
+                            "return ARGV[1]", List.of("key1", "key2"), List.of("arg1", "arg2")));
+            assertEquals(
+                    9L,
+                    adapter.evalScript(
+                            "return ARGV[1]", List.of("key1", "key2"), List.of("arg1", "arg2")));
+            returnType.verifyNoInteractions();
+        }
+        verify(redissonClient, times(3)).getScript(StringCodec.INSTANCE);
+        verify(script, times(3))
+                .eval(
+                        RScript.Mode.READ_WRITE,
+                        "return ARGV[1]",
+                        longReturnType,
+                        List.of("key1", "key2"),
+                        "arg1",
+                        "arg2");
+    }
+
+    @Test
+    void evalScriptRejectsNonnumericAndNullResults() {
+        RedissonClientAdapter adapter = RedissonClientAdapter.of(redissonClient);
+        RScript script = mock(RScript.class);
+        when(redissonClient.getScript(StringCodec.INSTANCE)).thenReturn(script);
+        when(script.eval(
+                        RScript.Mode.READ_WRITE,
+                        "return ARGV[1]",
+                        RScript.ReturnType.LONG,
+                        List.of("key"),
+                        "arg"))
+                .thenReturn("42", (Object) null);
+
+        assertEquals(
+                "Unexpected Lua script result: 42",
+                assertThrows(
+                                IllegalStateException.class,
+                                () ->
+                                        adapter.evalScript(
+                                                "return ARGV[1]", List.of("key"), List.of("arg")))
+                        .getMessage());
+        assertEquals(
+                "Unexpected Lua script result: null",
+                assertThrows(
+                                IllegalStateException.class,
+                                () ->
+                                        adapter.evalScript(
+                                                "return ARGV[1]", List.of("key"), List.of("arg")))
+                        .getMessage());
+    }
+}

--- a/docs/v2/en/integration/distributed/redis.md
+++ b/docs/v2/en/integration/distributed/redis.md
@@ -14,7 +14,17 @@ title: Redis
 </dependency>
 ```
 
-The module does not force a specific Redis client — import whichever you use (Jedis / Lettuce / Redisson).
+Choose Jedis, Lettuce, or Redisson to match your project. The Redisson state-store integration requires the **Redisson 4.x API** (`RScript.ReturnType.LONG`); Redisson 3.x is incompatible. AgentScope currently manages and tests against **4.2.0**. For example, align a direct Redisson dependency with that version:
+
+```xml
+<dependency>
+    <groupId>org.redisson</groupId>
+    <artifactId>redisson</artifactId>
+    <version>4.2.0</version>
+</dependency>
+```
+
+If you manage your own Redisson Spring Boot starter, a 3.x starter (for example, 3.52.0) is incompatible with this state-store integration. Align the starter and its Redisson dependencies with the current 4.2.0 baseline and check the resolved runtime dependencies. Both `RedisAgentStateStore.builder().redissonClient(...)` and the deprecated `RedissonAgentStateStore` fail during construction when the loaded API lacks `LONG`. This check reports the incompatibility; it does not repair dependency resolution or make Redisson 3.x persistence supported.
 
 ## One-Line Setup
 

--- a/docs/v2/en/integration/session/redis.md
+++ b/docs/v2/en/integration/session/redis.md
@@ -23,7 +23,17 @@ This page has been superseded by [Distributed Storage — Redis](/v2/en/integrat
 </dependency>
 ```
 
-The module does not pin a Redis client — bring whatever you already use (Jedis / Lettuce / Redisson).
+Choose Jedis, Lettuce, or Redisson to match your project. The Redisson state-store integration requires the **Redisson 4.x API** (`RScript.ReturnType.LONG`); Redisson 3.x is incompatible. AgentScope currently manages and tests against **4.2.0**. For example, align a direct Redisson dependency with that version:
+
+```xml
+<dependency>
+    <groupId>org.redisson</groupId>
+    <artifactId>redisson</artifactId>
+    <version>4.2.0</version>
+</dependency>
+```
+
+If you manage your own Redisson Spring Boot starter, a 3.x starter (for example, 3.52.0) is incompatible with this state-store integration. Align the starter and its Redisson dependencies with the current 4.2.0 baseline and check the resolved runtime dependencies. Both `RedisAgentStateStore.builder().redissonClient(...)` and the deprecated `RedissonAgentStateStore` fail during construction when the loaded API lacks `LONG`. This check reports the incompatibility; it does not repair dependency resolution or make Redisson 3.x persistence supported.
 
 ## Quickstart (Lettuce, standalone)
 

--- a/docs/v2/zh/integration/distributed/redis.md
+++ b/docs/v2/zh/integration/distributed/redis.md
@@ -14,7 +14,17 @@ title: Redis
 </dependency>
 ```
 
-模块本身不强制依赖某一 Redis 客户端，按项目实际使用引入（Jedis / Lettuce / Redisson）。
+按项目需要选择 Jedis、Lettuce 或 Redisson。Redisson 状态存储集成要求使用 **Redisson 4.x API**（`RScript.ReturnType.LONG`），不兼容 Redisson 3.x。AgentScope 当前管理并测试的版本为 **4.2.0**。例如，可将直接引入的 Redisson 依赖对齐到该版本：
+
+```xml
+<dependency>
+    <groupId>org.redisson</groupId>
+    <artifactId>redisson</artifactId>
+    <version>4.2.0</version>
+</dependency>
+```
+
+如果自行管理 Redisson Spring Boot starter，3.x starter（例如 3.52.0）与此状态存储集成不兼容。请将 starter 及其 Redisson 依赖对齐到当前的 4.2.0 基线，并检查最终解析出的运行时依赖。当加载的 API 缺少 `LONG` 时，`RedisAgentStateStore.builder().redissonClient(...)` 和已弃用的 `RedissonAgentStateStore` 都会在构造阶段报错。此检查仅报告兼容性问题，不会修复依赖解析，也不会让 Redisson 3.x 支持状态持久化。
 
 ## 一键配置
 

--- a/docs/v2/zh/integration/session/redis.md
+++ b/docs/v2/zh/integration/session/redis.md
@@ -23,7 +23,17 @@ title: Redis 状态存储
 </dependency>
 ```
 
-模块本身不强制依赖某一客户端，按你项目里实际用的引入即可（Jedis / Lettuce / Redisson）。
+按项目需要选择 Jedis、Lettuce 或 Redisson。Redisson 状态存储集成要求使用 **Redisson 4.x API**（`RScript.ReturnType.LONG`），不兼容 Redisson 3.x。AgentScope 当前管理并测试的版本为 **4.2.0**。例如，可将直接引入的 Redisson 依赖对齐到该版本：
+
+```xml
+<dependency>
+    <groupId>org.redisson</groupId>
+    <artifactId>redisson</artifactId>
+    <version>4.2.0</version>
+</dependency>
+```
+
+如果自行管理 Redisson Spring Boot starter，3.x starter（例如 3.52.0）与此状态存储集成不兼容。请将 starter 及其 Redisson 依赖对齐到当前的 4.2.0 基线，并检查最终解析出的运行时依赖。当加载的 API 缺少 `LONG` 时，`RedisAgentStateStore.builder().redissonClient(...)` 和已弃用的 `RedissonAgentStateStore` 都会在构造阶段报错。此检查仅报告兼容性问题，不会修复依赖解析，也不会让 Redisson 3.x 支持状态持久化。
 
 ## 快速上手（Lettuce 单机）
 


### PR DESCRIPTION
## AgentScope-Java Version

In each existing Redisson constructor, resolve `RScript.ReturnType.valueOf("LONG")` into a final instance field and translate a missing constant into an actionable `IllegalStateException` explaining that this state-store integration requires the Redisson 4.x API, that 3.x is incompatible, and that the project currently manages 4.2.0. Preserve existing argument validation in the deprecated store, resolve the constant before any Redis operations, retain the original exception as the cause, and include the loaded Redisson API package implementation version when available with an explicit unknown fallback; capability detection, rather than parsing a nullable version string, decides compatibility. Use that stored return type in `RedissonClientAdapter.evalScript` and `RedissonAgentStateStore.evalSave`, covering both production script callers without a new helper, injectable resolver, static initializer, or INTEGER fallback.

The reporter encounters `NoSuchFieldError: RScript$ReturnType.LONG` when persisting agent state with AgentScope 2.0.3 and Redisson starter 3.52.0. The September 11 COLLABORATOR evaluation confirms the failure but corrects its cause: Redisson 3.x exposes INTEGER, while AgentScope's code targets the LONG constant introduced in 4.x; the evaluation reports no embedded `org/redisson/**` classes in the published aggregate. The local clone corroborates both LONG references and the BOM's Redisson 4.2.0 baseline, and its Redis extension already declares Redisson as a dependency. The thread proposes a construction-time guard and version documentation separately from an aggregate packaging decision, which remains pending.

Fixes #3063

## Description

In each existing Redisson constructor, resolve `RScript.ReturnType.valueOf("LONG")` into a final instance field and translate a missing constant into an actionable `IllegalStateException` explaining that this state-store integration requires the Redisson 4.x API, that 3.x is incompatible, and that the project currently manages 4.2.0. Preserve existing argument validation in the deprecated store, resolve the constant before any Redis operations, retain the original exception as the cause, and include the loaded Redisson API package implementation version when available with an explicit unknown fallback; capability detection, rather than parsing a nullable version string, decides compatibility. Use that stored return type in `RedissonClientAdapter.evalScript` and `RedissonAgentStateStore.evalSave`, covering both production script callers without a new helper, injectable resolver, static initializer, or INTEGER fallback.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ] Code has been formatted with `mvn spotless:apply`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] All tests are passing (`mvn test`)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [x] Javadoc comments are complete and follow project conventions
- [ ]  Related documentation has been updated (e.g. links, examples, etc.)
- [x] Code is ready for review
