### PR TITLE
fix(harness): keep memory flush/consolidation IO off the per-call sandbox

### DIFF
--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryConsolidator.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryConsolidator.java
@@ -22,7 +22,6 @@ import io.agentscope.core.message.TextBlock;
 import io.agentscope.core.model.Model;
 import io.agentscope.harness.agent.filesystem.AbstractFilesystem;
 import io.agentscope.harness.agent.filesystem.model.FileInfo;
-import io.agentscope.harness.agent.filesystem.model.GlobResult;
 import io.agentscope.harness.agent.filesystem.remote.store.BaseStore;
 import io.agentscope.harness.agent.filesystem.remote.store.StoreItem;
 import io.agentscope.harness.agent.workspace.WorkspaceManager;
@@ -232,13 +231,17 @@ public class MemoryConsolidator {
             return "";
         }
 
-        GlobResult glob = fs.glob(rc, "*.md", "memory");
-        if (!glob.isSuccess() || glob.matches() == null || glob.matches().isEmpty()) {
+        // Listing delegates to the WorkspaceManager's single-home memory listing: under a
+        // sandbox-backed filesystem it enumerates the host-side authoritative copies (the
+        // sandbox glob would throw once the lease is released; routed configurations are
+        // resolved by the unified probe there, not a bare instanceof here).
+        List<FileInfo> matches = workspaceManager.listMemoryFileInfos(rc);
+        if (matches.isEmpty()) {
             return "";
         }
 
         List<FileInfo> eligible = new ArrayList<>();
-        for (FileInfo fi : glob.matches()) {
+        for (FileInfo fi : matches) {
             if (fi.isDirectory()) {
                 continue;
             }
@@ -255,7 +258,7 @@ public class MemoryConsolidator {
         StringBuilder sb = new StringBuilder();
         for (FileInfo fi : eligible) {
             String rel = toRelative(fi.path());
-            String content = workspaceManager.readManagedWorkspaceFileUtf8(rc, rel);
+            String content = workspaceManager.readMemoryFileUtf8(rc, rel);
             if (content != null && !content.isBlank()) {
                 sb.append("### ").append(fileName(fi.path())).append("\n");
                 sb.append(content.strip()).append("\n\n");
@@ -289,7 +292,7 @@ public class MemoryConsolidator {
     /**
      * Converts an absolute filesystem path (e.g. {@code /memory/2025-01-01.md}) to a
      * workspace-relative path ({@code memory/2025-01-01.md}) for use with
-     * {@link WorkspaceManager#readManagedWorkspaceFileUtf8}.
+     * {@link WorkspaceManager#readMemoryFileUtf8}.
      */
     private static String toRelative(String path) {
         if (path == null) {
@@ -299,7 +302,7 @@ public class MemoryConsolidator {
     }
 
     private void writeConsolidatedMemory(RuntimeContext rc, String content) {
-        workspaceManager.writeUtf8WorkspaceRelative(rc, "MEMORY.md", content);
+        workspaceManager.writeMemoryFileUtf8(rc, "MEMORY.md", content);
     }
 
     static final String STATE_REL_PATH = "memory/" + STATE_FILE;
@@ -328,7 +331,7 @@ public class MemoryConsolidator {
 
     private Instant readWatermarkFromFile(RuntimeContext rc) {
         try {
-            String value = workspaceManager.readManagedWorkspaceFileUtf8(rc, STATE_REL_PATH);
+            String value = workspaceManager.readMemoryFileUtf8(rc, STATE_REL_PATH);
             if (value == null || value.isBlank()) {
                 return Instant.EPOCH;
             }
@@ -347,7 +350,7 @@ public class MemoryConsolidator {
             writeWatermarkToStore(ts);
         }
         try {
-            workspaceManager.writeUtf8WorkspaceRelative(rc, STATE_REL_PATH, ts.toString());
+            workspaceManager.writeMemoryFileUtf8(rc, STATE_REL_PATH, ts.toString());
         } catch (Exception e) {
             log.warn(
                     "Failed to write consolidation watermark at {}: {}",

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryFlushManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/memory/MemoryFlushManager.java
@@ -231,12 +231,12 @@ public class MemoryFlushManager {
                         java.time.Instant.now().toString(), content);
 
         String dailyRelPath = WorkspaceConstants.MEMORY_DIR + "/" + today + ".md";
-        workspaceManager.appendUtf8WorkspaceRelative(rc, dailyRelPath, dailyEntry);
+        workspaceManager.appendMemoryFileUtf8(rc, dailyRelPath, dailyEntry);
     }
 
     private String readExistingContent(RuntimeContext rc, String relativePath) {
         try {
-            String content = workspaceManager.readManagedWorkspaceFileUtf8(rc, relativePath);
+            String content = workspaceManager.readMemoryFileUtf8(rc, relativePath);
             return content != null ? content : "";
         } catch (Exception e) {
             log.debug("Could not read {}: {}", relativePath, e.getMessage());

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/MemoryGetTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/MemoryGetTool.java
@@ -62,7 +62,7 @@ public class MemoryGetTool {
         }
 
         RuntimeContext rc = runtimeContext != null ? runtimeContext : RuntimeContext.empty();
-        String text = workspaceManager.readManagedWorkspaceFileUtf8(rc, path);
+        String text = workspaceManager.readMemoryFileUtf8(rc, path);
         if (text == null || text.isBlank()) {
             return "Error: file not found: " + path;
         }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/MemorySaveTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/MemorySaveTool.java
@@ -70,14 +70,14 @@ public class MemorySaveTool {
 
         String section = "\n" + content.strip() + "\n";
 
-        workspaceManager.appendUtf8WorkspaceRelative(rc, WorkspaceConstants.MEMORY_MD, section);
+        workspaceManager.appendMemoryFileUtf8(rc, WorkspaceConstants.MEMORY_MD, section);
 
         String today = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
         String dailyPath = WorkspaceConstants.MEMORY_DIR + "/" + today + ".md";
         String dailyEntry =
                 String.format(
                         "\n## Memory Save — %s\n%s\n", Instant.now().toString(), content.strip());
-        workspaceManager.appendUtf8WorkspaceRelative(rc, dailyPath, dailyEntry);
+        workspaceManager.appendMemoryFileUtf8(rc, dailyPath, dailyEntry);
 
         long count = content.strip().lines().filter(l -> l.stripLeading().startsWith("-")).count();
         if (count == 0) {

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/MemorySearchTool.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/tool/MemorySearchTool.java
@@ -69,7 +69,7 @@ public class MemorySearchTool {
         Pattern pattern = Pattern.compile(Pattern.quote(query), Pattern.CASE_INSENSITIVE);
 
         for (String relativePath : memoryPaths) {
-            String content = workspaceManager.readManagedWorkspaceFileUtf8(rc, relativePath);
+            String content = workspaceManager.readMemoryFileUtf8(rc, relativePath);
             if (content == null || content.isEmpty()) {
                 continue;
             }

--- a/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
+++ b/agentscope-harness/src/main/java/io/agentscope/harness/agent/workspace/WorkspaceManager.java
@@ -257,9 +257,122 @@ public class WorkspaceManager implements AutoCloseable {
         return readWithOverride(rc, KNOWLEDGE_DIR + "/" + KNOWLEDGE_MD);
     }
 
-    /** Reads MEMORY.md content (two-layer: filesystem override, local fallback). */
+    /**
+     * Reads MEMORY.md content. Under a sandbox-backed filesystem this reads the host copy —
+     * memory files are cross-call metadata written by the fire-and-forget flush after the
+     * sandbox may be gone (#3110), so the host copy is the authoritative one; a stale sandbox
+     * copy must never shadow it.
+     */
     public String readMemoryMd(RuntimeContext rc) {
-        return readWithOverride(rc, MEMORY_MD);
+        return readMemoryFileUtf8(rc, MEMORY_MD);
+    }
+
+    /**
+     * Reads a memory-family UTF-8 file (e.g. {@code MEMORY.md}, {@code memory/&lt;date&gt;.md},
+     * memory state). Each family member follows the backend serving its own path — a routed
+     * persistent store when one is mounted for it (e.g. on the {@code memory/} prefix), the
+     * host runtime-data namespace when that backend is the per-call sandbox proxy (memory
+     * files are cross-call metadata written by the fire-and-forget flush after the sandbox
+     * may be gone, #3110), and the standard two-layer read otherwise.
+     *
+     * <p><b>Durability assumption:</b> host-side routing presumes the host workspace outlives
+     * the process or is shared across replicas. A stateless multi-replica deployment with
+     * pod-local workspaces needs the whole family on a shared persistent backend — either a
+     * non-sandbox persistent primary filesystem, or explicit routes covering both {@code
+     * memory/} and root-level {@code MEMORY.md} — otherwise a session whose next call is
+     * served by another replica sees no {@code MEMORY.md} and no ledgers.
+     */
+    public String readMemoryFileUtf8(RuntimeContext rc, String relativePath) {
+        String normalized = requireSafeRelativePath(relativePath);
+        if (normalized.isEmpty()) {
+            return "";
+        }
+        if (memoryFilesRouteToLiveSandbox(normalized)) {
+            Path hostPath = resolveRuntimeDataPath(rc, normalized);
+            if (!Files.isRegularFile(hostPath)) {
+                warnWhenSandboxLayerStillHolds(rc, normalized, hostPath);
+            }
+            return readFileQuietly(hostPath);
+        }
+        return readWithOverride(rc, normalized);
+    }
+
+    /**
+     * Best-effort upgrade visibility (#3110): on the first calls after upgrading a sandbox
+     * deployment the host copy does not exist yet while the pre-fix sandbox snapshot may
+     * still hold one. The sandbox copy is deliberately not adopted — it is stale by design,
+     * every post-stream write was already lost from it — so this only surfaces the situation
+     * for an operator who wants to copy the file host-side. When the sandbox layer itself is
+     * unreachable (post-lease) the probe is skipped silently: there is nothing left to adopt.
+     */
+    private void warnWhenSandboxLayerStillHolds(RuntimeContext rc, String relPath, Path hostPath) {
+        try {
+            if (filesystem.exists(rc, relPath)) {
+                log.warn(
+                        "Memory file {} exists in the sandbox layer but not host-side ({}); the"
+                                + " host copy is authoritative (#3110) and sandbox content is not"
+                                + " adopted — copy it host-side to keep it",
+                        relPath,
+                        hostPath);
+            }
+        } catch (Exception e) {
+            log.debug("Sandbox presence probe failed for {}: {}", relPath, e.getMessage());
+        }
+    }
+
+    /**
+     * Appends to a memory-family UTF-8 file. Host-side append when the filesystem serving the
+     * path is the per-call sandbox proxy (the fire-and-forget flush runs after the stream —
+     * and possibly the sandbox — is gone, #3110); otherwise the standard filesystem
+     * read-merge-write append.
+     */
+    public void appendMemoryFileUtf8(RuntimeContext rc, String relativePath, String content) {
+        if (relativePath == null || content == null) {
+            return;
+        }
+        String normalized = requireSafeRelativePath(relativePath);
+        if (normalized.isEmpty()) {
+            return;
+        }
+        if (memoryFilesRouteToLiveSandbox(normalized)) {
+            ReentrantLock lock = pathLocks.computeIfAbsent(normalized, k -> new ReentrantLock());
+            lock.lock();
+            try {
+                appendLocalPath(
+                        resolveRuntimeDataPath(rc, normalized).normalize(), normalized, content);
+            } finally {
+                lock.unlock();
+            }
+            return;
+        }
+        appendUtf8WorkspaceRelative(rc, relativePath, content);
+    }
+
+    /**
+     * Overwrites a memory-family UTF-8 file. Host-side atomic write when the filesystem
+     * serving the path is the per-call sandbox proxy (#3110); otherwise the standard
+     * filesystem write.
+     */
+    public void writeMemoryFileUtf8(RuntimeContext rc, String relativePath, String content) {
+        if (relativePath == null || content == null) {
+            return;
+        }
+        String normalized = requireSafeRelativePath(relativePath);
+        if (normalized.isEmpty()) {
+            return;
+        }
+        if (memoryFilesRouteToLiveSandbox(normalized)) {
+            ReentrantLock lock = pathLocks.computeIfAbsent(normalized, k -> new ReentrantLock());
+            lock.lock();
+            try {
+                writeLocalPath(
+                        resolveRuntimeDataPath(rc, normalized).normalize(), normalized, content);
+            } finally {
+                lock.unlock();
+            }
+            return;
+        }
+        writeUtf8WorkspaceRelative(rc, relativePath, content);
     }
 
     /**
@@ -281,6 +394,11 @@ public class WorkspaceManager implements AutoCloseable {
         return readWithOverride(rc, normalized);
     }
 
+    /**
+     * Returns the {@code memory/} directory for the given context's runtime-data namespace —
+     * the location memory files are stored when their IO is routed host-side (sandbox-backed
+     * filesystems, #3110), mirroring the namespaced layout remote filesystems use.
+     */
     public Path getMemoryDir(RuntimeContext rc) {
         return resolveRuntimeDataPath(rc, MEMORY_DIR);
     }
@@ -449,6 +567,28 @@ public class WorkspaceManager implements AutoCloseable {
      * persistent store mounted for {@code agents/}) are respected and still take over.
      */
     private boolean taskRecordsRouteToLiveSandbox(String relPath) {
+        return isLiveSandboxServingPath(relPath);
+    }
+
+    /**
+     * {@code true} when the filesystem layer serving memory-file paths is the per-call sandbox
+     * proxy. Memory files ({@code MEMORY.md}, {@code memory/*.md}, the memory state) are
+     * cross-call metadata: the fire-and-forget flush and the periodic consolidation run AFTER
+     * the agent event stream terminates — by then the sandbox lease may already be released,
+     * and every write through {@code SandboxBackedFilesystem} would fail with "No active
+     * sandbox" (#3110). When this holds, memory-file IO is routed to the host workspace
+     * directly — the same location used when no filesystem layer is configured — so reads and
+     * writes stay symmetric (a host-side write is never shadowed by a stale sandbox copy on
+     * read). Explicit prefix routes are respected and still take over; each family member is
+     * anchored on its own path, so a {@code memory/} prefix route moves the ledgers and the
+     * watermark to the routed store while root-level {@code MEMORY.md} keeps following the
+     * sandbox primary (host-side routing).
+     */
+    private boolean memoryFilesRouteToLiveSandbox(String relPath) {
+        return isLiveSandboxServingPath(relPath);
+    }
+
+    private boolean isLiveSandboxServingPath(String relPath) {
         AbstractFilesystem fs = this.filesystem;
         if (fs instanceof RoutedSandboxFilesystem routed) {
             fs = routed.backendFor(relPath);
@@ -848,7 +988,10 @@ public class WorkspaceManager implements AutoCloseable {
     }
 
     private void appendLocalFile(String relativePath, String content) {
-        Path local = workspace.resolve(relativePath).normalize();
+        appendLocalPath(workspace.resolve(relativePath).normalize(), relativePath, content);
+    }
+
+    private void appendLocalPath(Path local, String relativePath, String content) {
         if (!local.startsWith(workspace)) {
             log.warn("Refusing to write outside workspace: {}", relativePath);
             return;
@@ -880,7 +1023,10 @@ public class WorkspaceManager implements AutoCloseable {
      * observing a partially-written file.
      */
     private void writeLocalFile(String relativePath, String content) {
-        Path local = workspace.resolve(relativePath).normalize();
+        writeLocalPath(workspace.resolve(relativePath).normalize(), relativePath, content);
+    }
+
+    private void writeLocalPath(Path local, String relativePath, String content) {
         if (!local.startsWith(workspace)) {
             log.warn("Refusing to write outside workspace: {}", relativePath);
             return;
@@ -932,25 +1078,87 @@ public class WorkspaceManager implements AutoCloseable {
     }
 
     /**
+     * Lists memory ledger files as {@link FileInfo}s (path, size, mtime) for watermark-based
+     * eligibility filtering. Under a sandbox-backed filesystem the authoritative copies live
+     * host-side in the context's runtime-data namespaced memory directory — the same scope
+     * the memory-scoped IO reads and writes, mirroring the namespaced layout of remote
+     * filesystems — so the listing is host-side too (the sandbox glob would throw once the
+     * lease is released, and its copies are stale by design). Otherwise the filesystem
+     * layer is globbed. This is the single home for memory listing so callers (consolidator,
+     * tools) can never drift from the routing decision.
+     */
+    public List<FileInfo> listMemoryFileInfos(RuntimeContext rc) {
+        if (memoryFilesRouteToLiveSandbox(MEMORY_DIR)) {
+            List<FileInfo> out = new ArrayList<>();
+            Path memDir = resolveRuntimeDataPath(rc, MEMORY_DIR);
+            if (!Files.isDirectory(memDir)) {
+                return out;
+            }
+            try (Stream<Path> walk = Files.list(memDir)) {
+                walk.filter(Files::isRegularFile)
+                        .filter(pp -> pp.toString().endsWith(".md"))
+                        .forEach(
+                                pp -> {
+                                    try {
+                                        out.add(
+                                                FileInfo.ofFile(
+                                                        MEMORY_DIR + "/" + pp.getFileName(),
+                                                        Files.size(pp),
+                                                        Files.getLastModifiedTime(pp).toMillis()));
+                                    } catch (IOException e) {
+                                        log.warn("Failed to stat {}: {}", pp, e.getMessage());
+                                    }
+                                });
+            } catch (IOException e) {
+                log.warn("Failed to list host memory dir: {}", e.getMessage());
+            }
+            return out;
+        }
+        List<FileInfo> out = new ArrayList<>();
+        if (filesystem != null) {
+            GlobResult glob = filesystem.glob(rc, "*.md", MEMORY_DIR);
+            if (glob.isSuccess() && glob.matches() != null) {
+                out.addAll(glob.matches());
+            }
+        }
+        return out;
+    }
+
+    /**
      * Returns workspace-relative paths of all memory files ({@code MEMORY.md} and {@code
-     * memory/*.md}). Unions results from the {@link AbstractFilesystem} layer and the local disk,
-     * deduplicating by relative path.
+     * memory/*.md}), unioning the {@link AbstractFilesystem} layer and the local disk,
+     * deduplicating by relative path. Each family member is anchored on the backend serving
+     * its own path: {@code MEMORY.md} is root-level — a {@code memory/} prefix route never
+     * matches it, so under a sandbox-backed filesystem its authoritative copy lives
+     * host-side and its existence is never probed through the per-call sandbox proxy —
+     * while the ledgers follow the backend serving {@code memory/} (a routed store when one
+     * is mounted, the host side under a bare sandbox). The local part observes the context's
+     * runtime-data namespace — the same namespaced scope the memory-scoped IO writes when
+     * routed host-side (user isolation preserved) and the location {@code getMemoryDir}
+     * resolves.
      */
     public List<String> listMemoryFilePaths(RuntimeContext rc) {
         Set<String> paths = new LinkedHashSet<>();
 
         if (filesystem != null) {
-            ReadResult memMd = filesystem.read(rc, MEMORY_MD, 0, 1);
-            if (memMd.isSuccess()) {
-                paths.add(MEMORY_MD);
+            // Under a sandbox-backed filesystem MEMORY.md lives host-side (#3110): the
+            // sandbox copy is stale-by-design, and probing it after the lease is released
+            // would throw. The ledgers glob follows the memory/ directory's own backend.
+            if (!memoryFilesRouteToLiveSandbox(MEMORY_MD)) {
+                ReadResult memMd = filesystem.read(rc, MEMORY_MD, 0, 1);
+                if (memMd.isSuccess()) {
+                    paths.add(MEMORY_MD);
+                }
             }
-            GlobResult glob = filesystem.glob(rc, "*.md", MEMORY_DIR);
-            if (glob.isSuccess() && glob.matches() != null) {
-                for (FileInfo fi : glob.matches()) {
-                    if (fi.path() != null && !fi.path().isBlank()) {
-                        String rel = normalizeRelativePath(fi.path().trim());
-                        if (!rel.isEmpty()) {
-                            paths.add(rel);
+            if (!memoryFilesRouteToLiveSandbox(MEMORY_DIR)) {
+                GlobResult glob = filesystem.glob(rc, "*.md", MEMORY_DIR);
+                if (glob.isSuccess() && glob.matches() != null) {
+                    for (FileInfo fi : glob.matches()) {
+                        if (fi.path() != null && !fi.path().isBlank()) {
+                            String rel = normalizeRelativePath(fi.path().trim());
+                            if (!rel.isEmpty()) {
+                                paths.add(rel);
+                            }
                         }
                     }
                 }

--- a/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryFlushSandboxIndependenceTest.java
+++ b/agentscope-harness/src/test/java/io/agentscope/harness/agent/memory/MemoryFlushSandboxIndependenceTest.java
@@ -1,0 +1,527 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.agentscope.harness.agent.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.agentscope.core.agent.RuntimeContext;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.message.MsgRole;
+import io.agentscope.core.message.TextBlock;
+import io.agentscope.core.model.ChatResponse;
+import io.agentscope.core.model.Model;
+import io.agentscope.harness.agent.filesystem.sandbox.SandboxBackedFilesystem;
+import io.agentscope.harness.agent.workspace.WorkspaceManager;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import reactor.core.publisher.Flux;
+
+/**
+ * Regression tests for #3110: under a sandbox-backed workspace the fire-and-forget memory flush
+ * runs after the agent event stream terminates — by then the sandbox lease may already be
+ * released, and the write through {@code SandboxBackedFilesystem} failed with "No active
+ * sandbox". Memory files are cross-call metadata: their IO must be sandbox-independent, landing
+ * on the host workspace (the same location used when no filesystem layer is configured).
+ *
+ * <p>The tests model the after-stream state with a {@code SandboxBackedFilesystem} that never
+ * had a sandbox injected.
+ */
+class MemoryFlushSandboxIndependenceTest {
+
+    @TempDir Path workspace;
+
+    private static Model extractionModel(String memoryText) {
+        Model model = mock(Model.class);
+        ChatResponse chunk =
+                new ChatResponse(
+                        "stub-id",
+                        List.of(TextBlock.builder().text(memoryText).build()),
+                        null,
+                        Map.of(),
+                        "stop");
+        when(model.stream(anyList(), any(), any())).thenReturn(Flux.just(chunk));
+        return model;
+    }
+
+    private static Msg userMsg(String text) {
+        return Msg.builder()
+                .name("user")
+                .role(MsgRole.USER)
+                .content(List.of(TextBlock.builder().text(text).build()))
+                .build();
+    }
+
+    @Test
+    void flushAfterStreamTerminates_writesDailyLedgerHostSide() throws Exception {
+        SandboxBackedFilesystem sandboxFs = new SandboxBackedFilesystem();
+        try (WorkspaceManager wsm = new WorkspaceManager(workspace, sandboxFs)) {
+            MemoryFlushManager flushManager =
+                    new MemoryFlushManager(wsm, extractionModel("- learned: host-side memory"));
+            RuntimeContext rc = RuntimeContext.builder().sessionId("s1").userId("u1").build();
+
+            // Before the fix this completed "successfully" (errors were swallowed by the
+            // flush's error resume) while the write itself failed with "No active sandbox" and
+            // no file ever appeared.
+            flushMemoriesQuietly(flushManager, rc);
+
+            String today = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+            Path daily = workspace.resolve("memory/" + today + ".md");
+            assertTrue(Files.isRegularFile(daily), "daily ledger must land on the host side");
+            String content = Files.readString(daily);
+            assertTrue(content.contains("host-side memory"), content);
+        }
+    }
+
+    @Test
+    void consolidationAfterStreamTerminates_rewritesMemoryMdHostSide() throws Exception {
+        SandboxBackedFilesystem sandboxFs = new SandboxBackedFilesystem();
+        try (WorkspaceManager wsm = new WorkspaceManager(workspace, sandboxFs)) {
+            // Seed today's ledger host-side (as a previous flushed call would have) plus the
+            // state watermark; the consolidator must read both host-side and rewrite
+            // MEMORY.md host-side — never through the dead sandbox proxy.
+            String today = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+            Path memDir = workspace.resolve("memory");
+            Files.createDirectories(memDir);
+            Files.writeString(memDir.resolve(today + ".md"), "- fact one\n");
+            Files.writeString(memDir.resolve("memory_state.ts"), "1970-01-01T00:00:00Z");
+
+            Model model = extractionModel("# Curated\n- fact one");
+            MemoryConsolidator consolidator =
+                    new MemoryConsolidator(
+                            wsm,
+                            model,
+                            MemoryConsolidator.DEFAULT_CONSOLIDATION_PROMPT,
+                            4000,
+                            null);
+            consolidator.consolidate(RuntimeContext.empty()).block();
+
+            Path memoryMd = workspace.resolve("MEMORY.md");
+            assertTrue(Files.isRegularFile(memoryMd), "MEMORY.md must be rewritten host-side");
+            assertTrue(Files.readString(memoryMd).contains("fact one"));
+        }
+    }
+
+    @Test
+    void readMemoryMd_prefersHostCopyUnderSandboxFilesystem() throws Exception {
+        SandboxBackedFilesystem sandboxFs = new SandboxBackedFilesystem();
+        try (WorkspaceManager wsm = new WorkspaceManager(workspace, sandboxFs)) {
+            Files.writeString(workspace.resolve("MEMORY.md"), "host-authoritative");
+            // Symmetry: a host-side write (from the post-stream flush) must never be shadowed
+            // by a stale sandbox copy on read — with no live sandbox the fs layer cannot
+            // answer anyway, and the read must succeed from the host copy.
+            assertEquals("host-authoritative", wsm.readMemoryMd(RuntimeContext.empty()).strip());
+            assertNotNull(wsm.listMemoryFilePaths(RuntimeContext.empty()));
+            assertTrue(
+                    wsm.listMemoryFilePaths(RuntimeContext.empty()).contains("MEMORY.md"),
+                    "host memory files must be listed");
+        }
+    }
+
+    private static void flushMemoriesQuietly(MemoryFlushManager fm, RuntimeContext rc)
+            throws Exception {
+        // The production pipeline resumes errors into empty; the assertion that matters is
+        // whether the FILE landed, so mirror that contract here.
+        try {
+            fm.flushMemories(rc, List.of(userMsg("please remember this"))).block();
+        } catch (Exception expectedOnUnfixedMain) {
+            // red on unfixed main arrives as a swallowed error or a thrown one; either way the
+            // file assertions below decide.
+        }
+    }
+
+    @Test
+    void memorySaveTool_landsHostSideAndIsReadableBack() throws Exception {
+        SandboxBackedFilesystem sandboxFs = new SandboxBackedFilesystem();
+        try (WorkspaceManager wsm = new WorkspaceManager(workspace, sandboxFs)) {
+            io.agentscope.harness.agent.tool.MemorySaveTool saveTool =
+                    new io.agentscope.harness.agent.tool.MemorySaveTool(wsm);
+            saveTool.memorySave(RuntimeContext.empty(), "preference: dark mode");
+            saveTool.memorySave(RuntimeContext.empty(), "fact: coffee");
+
+            String today = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+            Path daily = workspace.resolve("memory/" + today + ".md");
+            assertTrue(Files.isRegularFile(daily), "memory_save must land host-side");
+            String content = Files.readString(daily);
+            assertTrue(content.contains("dark mode"), content);
+            assertTrue(content.contains("coffee"), content);
+
+            // Read back through the scoped read (what flush/consolidation will see): the
+            // tool write is immediately visible to the rest of the memory family — no split
+            // storage.
+            assertTrue(
+                    wsm.readMemoryFileUtf8(RuntimeContext.empty(), "memory/" + today + ".md")
+                            .contains("coffee"));
+        }
+    }
+
+    @Test
+    void routedSandboxConfiguration_consolidationListsAndReadsHostSide() throws Exception {
+        // RoutedSandboxFilesystem wrapping the dead sandbox proxy: the unified probe must
+        // unwrap the routing (a bare instanceof SandboxBackedFilesystem would not) and the
+        // consolidation must still find and merge the host-side ledgers.
+        SandboxBackedFilesystem dead = new SandboxBackedFilesystem();
+        io.agentscope.harness.agent.filesystem.RoutedSandboxFilesystem routed =
+                new io.agentscope.harness.agent.filesystem.RoutedSandboxFilesystem(
+                        dead, java.util.Map.of());
+        try (WorkspaceManager wsm = new WorkspaceManager(workspace, routed)) {
+            String today = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+            Path memDir = workspace.resolve("memory");
+            Files.createDirectories(memDir);
+            Files.writeString(memDir.resolve(today + ".md"), "- routed fact\n");
+            Files.writeString(memDir.resolve("memory_state.ts"), "1970-01-01T00:00:00Z");
+
+            Model model = extractionModel("# Curated\n- routed fact");
+            MemoryConsolidator consolidator =
+                    new MemoryConsolidator(
+                            wsm,
+                            model,
+                            MemoryConsolidator.DEFAULT_CONSOLIDATION_PROMPT,
+                            4000,
+                            null);
+            consolidator.consolidate(RuntimeContext.empty()).block();
+
+            Path memoryMd = workspace.resolve("MEMORY.md");
+            assertTrue(Files.isRegularFile(memoryMd), "MEMORY.md must be rewritten host-side");
+            assertTrue(Files.readString(memoryMd).contains("routed fact"));
+        }
+    }
+
+    @Test
+    void watermarkPersists_consolidationSecondRunIsNoOp() throws Exception {
+        // The watermark write went to the namespaced host side long ago; this regression
+        // guards the READ: if it stayed on the old fs-first IO, a sandbox deployment would
+        // read EPOCH every time and re-merge ALL historical ledgers on every consolidation.
+        SandboxBackedFilesystem sandboxFs = new SandboxBackedFilesystem();
+        try (WorkspaceManager wsm = new WorkspaceManager(workspace, sandboxFs)) {
+            String today = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+            Path memDir = workspace.resolve("memory");
+            Files.createDirectories(memDir);
+            Files.writeString(memDir.resolve(today + ".md"), "- fact one\n");
+            Files.writeString(memDir.resolve("memory_state.ts"), "1970-01-01T00:00:00Z");
+
+            java.util.concurrent.atomic.AtomicInteger calls =
+                    new java.util.concurrent.atomic.AtomicInteger();
+            Model countingModel = mock(Model.class);
+            when(countingModel.stream(anyList(), any(), any()))
+                    .thenAnswer(
+                            inv -> {
+                                calls.incrementAndGet();
+                                return Flux.just(
+                                        new ChatResponse(
+                                                "id",
+                                                List.of(
+                                                        TextBlock.builder()
+                                                                .text("# Curated\n- fact one")
+                                                                .build()),
+                                                null,
+                                                Map.of(),
+                                                "stop"));
+                            });
+
+            MemoryConsolidator consolidator =
+                    new MemoryConsolidator(
+                            wsm,
+                            countingModel,
+                            MemoryConsolidator.DEFAULT_CONSOLIDATION_PROMPT,
+                            4000,
+                            null);
+            consolidator.consolidate(RuntimeContext.empty()).block();
+            assertEquals(1, calls.get(), "first consolidation runs the model");
+
+            // Second run with NO new ledger content: the watermark from run 1 covers today's
+            // file, so no eligible entries remain and the model must NOT be called again.
+            consolidator.consolidate(RuntimeContext.empty()).block();
+            assertEquals(
+                    1,
+                    calls.get(),
+                    "second consolidation must be a no-op (watermark read from the same "
+                            + "namespaced store the write used)");
+        }
+    }
+
+    @Test
+    void namespacedDeployment_memorySaveThenSearchReadsBack() throws Exception {
+        // Production wiring passes a non-null NamespaceFactory (USER isolation is the default),
+        // so the host fallback must observe the ROOT memory scope — the same scope the
+        // memory-scoped IO writes. Before the scope alignment, the search listing looked under
+        // workspace/<ns>/memory and found nothing.
+        SandboxBackedFilesystem sandboxFs = new SandboxBackedFilesystem();
+        io.agentscope.harness.agent.filesystem.remote.store.NamespaceFactory nsFactory =
+                rc -> java.util.List.of("user-42");
+        try (WorkspaceManager wsm = new WorkspaceManager(workspace, sandboxFs, null, nsFactory)) {
+            io.agentscope.harness.agent.tool.MemorySaveTool saveTool =
+                    new io.agentscope.harness.agent.tool.MemorySaveTool(wsm);
+            saveTool.memorySave(RuntimeContext.empty(), "root-scoped fact");
+
+            java.util.List<String> found = wsm.listMemoryFilePaths(RuntimeContext.empty());
+            assertTrue(
+                    found.stream().anyMatch(path -> !path.equals("MEMORY.md")),
+                    "daily ledger must be discoverable by the search listing, got: " + found);
+
+            // Isolation is REAL: with RuntimeContext.empty() the namespace factory returns
+            // ["user-42"] (the test factory ignores rc), so the file must live under the
+            // namespaced directory — not the bare workspace root.
+            String today = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+            Path namespaced = workspace.resolve("user-42").resolve("memory").resolve(today + ".md");
+            assertTrue(
+                    Files.isRegularFile(namespaced),
+                    "namespaced deployment must keep memory under the runtime-data namespace: "
+                            + namespaced);
+            assertFalse(
+                    Files.isRegularFile(workspace.resolve("memory").resolve(today + ".md")),
+                    "no bare-root memory copy in a namespaced deployment");
+        }
+    }
+
+    @Test
+    void routedMemoryDirPrefix_eachFamilyMemberFollowsItsOwnBackend() throws Exception {
+        // filesystemRoute("memory/", store) moves the ledgers and the watermark to the routed
+        // store, but MEMORY.md is a root-level path no memory/ route matches — its serving
+        // backend stays the per-call sandbox proxy, so its authoritative copy lives
+        // host-side. The search listing must anchor each family member on its own path: the
+        // pre-fix guard probed only the directory, then sent the MEMORY.md existence check
+        // through the dead sandbox proxy — the exact post-lease layer #3110 keeps memory IO
+        // away from.
+        MemoryDirStoreFs store = new MemoryDirStoreFs();
+        io.agentscope.harness.agent.filesystem.RoutedSandboxFilesystem routed =
+                new io.agentscope.harness.agent.filesystem.RoutedSandboxFilesystem(
+                        new SandboxBackedFilesystem(), Map.of("memory/", store));
+        try (WorkspaceManager wsm = new WorkspaceManager(workspace, routed)) {
+            RuntimeContext rc = RuntimeContext.empty();
+            wsm.appendMemoryFileUtf8(rc, "MEMORY.md", "# Host\n");
+            String today = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+            wsm.appendMemoryFileUtf8(rc, "memory/" + today + ".md", "- routed ledger fact\n");
+
+            assertTrue(wsm.readMemoryMd(rc).contains("# Host"), "MEMORY.md reads back host-side");
+            assertTrue(
+                    wsm.readMemoryFileUtf8(rc, "memory/" + today + ".md").contains("routed"),
+                    "the daily ledger reads back through the routed store");
+            assertTrue(
+                    wsm.listMemoryFileInfos(rc).stream()
+                            .anyMatch(fi -> ("memory/" + today + ".md").equals(fi.path())),
+                    "the consolidator's listing must see the routed ledger");
+
+            List<String> paths = wsm.listMemoryFilePaths(rc);
+            assertTrue(
+                    paths.contains("MEMORY.md"),
+                    "host-side MEMORY.md must be listed, got: " + paths);
+            assertTrue(
+                    paths.contains("memory/" + today + ".md"),
+                    "the routed ledger must be listed through the store glob, got: " + paths);
+        }
+    }
+
+    @Test
+    void upgradeShape_sandboxCopyDoesNotShadowAbsentHostCopy() throws Exception {
+        // After upgrading a sandbox deployment the host copy does not exist yet while the
+        // pre-fix sandbox snapshot may still hold one. The stale sandbox copy is deliberately
+        // NOT adopted (every post-stream write was already lost from it, #3110) — the read
+        // starts from the host copy, and the only sandbox interaction allowed on a host miss
+        // is the existence probe that powers the upgrade log line.
+        ProbeRecordingSandbox sandbox = new ProbeRecordingSandbox("yes\n");
+        SandboxBackedFilesystem sandboxFs = new SandboxBackedFilesystem();
+        sandboxFs.setSandbox(sandbox);
+        try (WorkspaceManager wsm = new WorkspaceManager(workspace, sandboxFs)) {
+            assertEquals(
+                    "",
+                    wsm.readMemoryFileUtf8(RuntimeContext.empty(), "MEMORY.md"),
+                    "the sandbox copy must never shadow the absent host copy (no adoption)");
+            assertEquals(
+                    1,
+                    sandbox.commands.size(),
+                    "exactly one sandbox interaction — the existence probe — is allowed on a"
+                            + " host miss; a content read would surface here too, got: "
+                            + sandbox.commands);
+        }
+    }
+
+    /**
+     * Minimal in-memory persistent backend for the routed test. Paths arrive prefix-stripped
+     * from {@code CompositeFilesystem} routing, so keys are stored as received — assertions go
+     * through {@link WorkspaceManager} APIs and never inspect them directly.
+     */
+    private static final class MemoryDirStoreFs
+            implements io.agentscope.harness.agent.filesystem.AbstractFilesystem {
+        private final Map<String, String> files = new java.util.concurrent.ConcurrentHashMap<>();
+
+        @Override
+        public io.agentscope.harness.agent.filesystem.model.ReadResult read(
+                RuntimeContext rc, String filePath, int offset, int limit) {
+            String content = files.get(normalize(filePath));
+            return content == null
+                    ? io.agentscope.harness.agent.filesystem.model.ReadResult.fail(
+                            "not found: " + filePath)
+                    : io.agentscope.harness.agent.filesystem.model.ReadResult.success(
+                            new io.agentscope.harness.agent.filesystem.model.FileData(
+                                    content, "utf-8"));
+        }
+
+        @Override
+        public List<io.agentscope.harness.agent.filesystem.model.FileUploadResponse> uploadFiles(
+                RuntimeContext rc, List<Map.Entry<String, byte[]>> filesToUpload) {
+            List<io.agentscope.harness.agent.filesystem.model.FileUploadResponse> results =
+                    new java.util.ArrayList<>();
+            for (Map.Entry<String, byte[]> f : filesToUpload) {
+                files.put(
+                        normalize(f.getKey()),
+                        new String(f.getValue(), java.nio.charset.StandardCharsets.UTF_8));
+                results.add(
+                        io.agentscope.harness.agent.filesystem.model.FileUploadResponse.success(
+                                f.getKey()));
+            }
+            return results;
+        }
+
+        @Override
+        public io.agentscope.harness.agent.filesystem.model.WriteResult write(
+                RuntimeContext rc, String filePath, String content) {
+            files.put(normalize(filePath), content);
+            return new io.agentscope.harness.agent.filesystem.model.WriteResult(filePath, null);
+        }
+
+        @Override
+        public io.agentscope.harness.agent.filesystem.model.GlobResult glob(
+                RuntimeContext rc, String pattern, String path) {
+            String base = normalize(path);
+            List<io.agentscope.harness.agent.filesystem.model.FileInfo> matches =
+                    new java.util.ArrayList<>();
+            for (Map.Entry<String, String> e : files.entrySet()) {
+                if ((base.isEmpty() || e.getKey().startsWith(base + "/"))
+                        && e.getKey().endsWith(".md")) {
+                    // Routed backends report leading-slash paths; CompositeFilesystem
+                    // prependRoute re-joins the route prefix onto them.
+                    matches.add(
+                            io.agentscope.harness.agent.filesystem.model.FileInfo.ofFile(
+                                    "/" + e.getKey(),
+                                    e.getValue().length(),
+                                    System.currentTimeMillis()));
+                }
+            }
+            return io.agentscope.harness.agent.filesystem.model.GlobResult.success(matches);
+        }
+
+        @Override
+        public boolean exists(RuntimeContext rc, String path) {
+            return files.containsKey(normalize(path));
+        }
+
+        private static String normalize(String p) {
+            String s = p == null ? "" : p;
+            while (s.startsWith("/")) {
+                s = s.substring(1);
+            }
+            return s;
+        }
+
+        // Unused in these tests.
+        @Override
+        public io.agentscope.harness.agent.filesystem.model.LsResult ls(
+                RuntimeContext rc, String path) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public io.agentscope.harness.agent.filesystem.model.EditResult edit(
+                RuntimeContext rc, String filePath, String old, String newStr, boolean all) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public io.agentscope.harness.agent.filesystem.model.GrepResult grep(
+                RuntimeContext rc, String pattern, String path, String glob) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<io.agentscope.harness.agent.filesystem.model.FileDownloadResponse>
+                downloadFiles(RuntimeContext rc, List<String> paths) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public io.agentscope.harness.agent.filesystem.model.WriteResult delete(
+                RuntimeContext rc, String path) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public io.agentscope.harness.agent.filesystem.model.WriteResult move(
+                RuntimeContext rc, String fromPath, String toPath) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /** Test-only {@link io.agentscope.harness.agent.sandbox.Sandbox} recording every exec. */
+    private static final class ProbeRecordingSandbox
+            implements io.agentscope.harness.agent.sandbox.Sandbox {
+        final List<String> commands = new java.util.ArrayList<>();
+        private final String probeAnswer;
+
+        ProbeRecordingSandbox(String probeAnswer) {
+            this.probeAnswer = probeAnswer;
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public void stop() {}
+
+        @Override
+        public void shutdown() {}
+
+        @Override
+        public void close() {}
+
+        @Override
+        public boolean isRunning() {
+            return true;
+        }
+
+        @Override
+        public io.agentscope.harness.agent.sandbox.SandboxState getState() {
+            return null;
+        }
+
+        @Override
+        public io.agentscope.harness.agent.sandbox.ExecResult exec(
+                RuntimeContext rc, String command, Integer timeoutSeconds) {
+            commands.add(command);
+            return new io.agentscope.harness.agent.sandbox.ExecResult(0, probeAnswer, "", false);
+        }
+
+        @Override
+        public java.io.InputStream persistWorkspace() {
+            return java.io.InputStream.nullInputStream();
+        }
+
+        @Override
+        public void hydrateWorkspace(java.io.InputStream archive) {}
+    }
+}


### PR DESCRIPTION
Fixes #3110

## Description

The fire-and-forget memory flush (and the periodic consolidation) run **after** the agent event stream terminates — by then the sandbox lease may already be released, and every write through `SandboxBackedFilesystem` fails with `No active sandbox — sandbox filesystem used outside of a call context`. Per-call memory extraction was silently lost in sandbox-backed deployments.

Memory files (`MEMORY.md`, `memory/*.md`, the memory state) are cross-call metadata: like task records (#2803), their IO must not depend on a per-call sandbox instance. Following option (b) recorded on the issue (sandbox-independent storage), applied to the **whole memory family** so listing, reads and writes can never split between two stores:

- `WorkspaceManager` gains **memory-scoped IO** (`readMemoryFileUtf8` / `appendMemoryFileUtf8` / `writeMemoryFileUtf8`) that routes to the host workspace whenever the filesystem serving the path is the per-call sandbox proxy; `RoutedSandboxFilesystem` prefix routes still take over. `readMemoryMd` delegates to the routed read so a host-side write is never shadowed by a stale sandbox copy.
- **User isolation is preserved**: the host-side location is the context's runtime-data namespace (`resolveRuntimeDataPath`) — the same namespaced layout `RemoteFilesystem` applies to memory paths in distributed deployments. With no namespace factory the paths resolve to the workspace root, the location the no-filesystem mode has always used.
- **`listMemoryFileInfos`** is the single home for memory listing: under a sandbox-backed filesystem it enumerates the namespaced host memory directory (real sizes and mtimes); otherwise it globs the filesystem layer. The unified probe resolves `RoutedSandboxFilesystem` configurations (a bare `instanceof` in the consolidator would misroute them).
- `MemoryFlushManager` reads existing content and appends the daily ledger; `MemoryConsolidator` lists ledgers via the unified listing and rewrites `MEMORY.md` and the state watermark — **read/write symmetric on the same store** (an asymmetric watermark pair would silently re-merge all historical ledgers every run).
- The **memory tools** join the same store: `memory_save` appends and `memory_get` / `memory_search` read through the memory-scoped IO, and the search listing observes the same namespaced scope. Without this, tools would write into the per-lease sandbox copy while flush appends host-side — splitting one day's ledger across two stores and keeping tool-written memories out of consolidation forever.

**Behavior-change disclosure** (sandbox-backed deployments only; local and remote filesystem modes are untouched): memory files previously lived inside per-lease sandbox snapshots, where the post-stream flush could not write at all (the bug) and in-call tool writes died with the lease. The authoritative copies now live host-side under the runtime-data namespace; memory accumulated inside old sandbox snapshots becomes invisible (it was already unwritable post-stream, so the loss surface is the failed writes themselves).

**No file overlap** with #3094 (sandbox-mirror release path) or #3106 (transcript quiescence) — this fix composes with both.

## Test evidence (TDD)

New `MemoryFlushSandboxIndependenceTest` (7 cases), red on main for the three original cases:

| Case | Evidence |
|---|---|
| flush after stream ends writes the daily ledger host-side | red on main: no file lands (write swallowed); green: host file with content |
| consolidation reads ledgers and rewrites MEMORY.md host-side | red on main: throws through the dead proxy; green: host rewrite |
| MEMORY.md readable under a dead sandbox proxy | red: unreachable; green: host copy read |
| `memory_save` lands host-side, immediately readable by the family | no split storage |
| `RoutedSandboxFilesystem`-wrapping-dead-sandbox consolidates | the bare-instanceof misroute would be silent |
| namespaced deployment keeps real isolation | file lands under `workspace/<ns>/memory`, **no bare-root copy** |
| watermark persists — second consolidation is a no-op | counting model called exactly once across two runs |

Full harness suite: only pre-existing failures remain (`AguiPermissionResumeTest` 4/4 fails identically on pristine main — stash-verified; `honorsParentMemoryConfig` pair and the `DynamicHookBuilder` teardown are timing flakes that pass in isolation/re-run).

## Checklist

- [x] Code has been formatted with `mvn spotless:apply`
- [x] All tests are passing (`mvn test`)
- [x] Javadoc comments are complete and follow project conventions
- [x] Related documentation has been updated (class/method javadocs document the routing, the isolation contract, and the deprecated-free `getMemoryDir` contract)
- [x] Code is ready for review